### PR TITLE
Enhance checkout flow with verified bank transfers

### DIFF
--- a/app/(site)/checkout/page.jsx
+++ b/app/(site)/checkout/page.jsx
@@ -1,13 +1,33 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useCart } from "@/components/cart/CartProvider";
 import QrBox from "@/components/QrBox";
 
+const REQUIRED_FIELDS = ["name", "phone", "email", "address1", "province", "postcode"];
+
+function isFormValid(form) {
+  return REQUIRED_FIELDS.every((key) => String(form[key]).trim() !== "");
+}
+
+function fmt(n) {
+  return Number(n || 0).toLocaleString("th-TH");
+}
+
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error("ไม่สามารถอ่านไฟล์ได้"));
+    reader.readAsDataURL(file);
+  });
+}
+
 export default function CheckoutPage() {
   const cart = useCart();
+  const router = useRouter();
 
-  // ฟอร์มลูกค้า/ที่อยู่จัดส่ง
   const [form, setForm] = useState({
     name: "",
     phone: "",
@@ -20,65 +40,64 @@ export default function CheckoutPage() {
     note: "",
   });
 
-  // สถานะการทำงาน
+  const [paymentMethod, setPaymentMethod] = useState("promptpay");
   const [err, setErr] = useState("");
-  const [loadingPreview, setLoadingPreview] = useState(false);
-  const [loadingPlace, setLoadingPlace] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [order, setOrder] = useState(null);
+  const [slipData, setSlipData] = useState("");
+  const [slipName, setSlipName] = useState("");
+  const [transferAmount, setTransferAmount] = useState("");
+  const [reference, setReference] = useState("");
 
-  // ผลลัพธ์จาก API
-  const [preview, setPreview] = useState(null);
-  const [placed, setPlaced] = useState(null);
+  const currentTotals = order?.orderPreview ?? {
+    items: cart.items.map((it) => ({ ...it, lineTotal: (it.price || 0) * it.qty })),
+    subtotal: cart.subtotal,
+    discount: cart.coupon?.discount || 0,
+    total: cart.subtotal - (cart.coupon?.discount || 0),
+    coupon: cart.coupon
+      ? { code: cart.coupon.code, description: cart.coupon.description, discount: cart.coupon.discount }
+      : null,
+  };
 
-  // helper
-  const fmt = (n) => Number(n || 0).toLocaleString("th-TH");
-
-  // ฟิลด์จำเป็น
-  const requiredFields = ["name", "phone", "email", "address1", "province", "postcode"];
-  const isFormValid = requiredFields.every((key) => String(form[key]).trim() !== "");
-
-  // --- พรีวิว ---
-  async function doPreview() {
-    setErr("");
-    setPreview(null);
-    setPlaced(null);
-    try {
-      setLoadingPreview(true);
-      const res = await fetch("/api/checkout/preview", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          method: "promptpay",
-          items: cart.items.map((x) => ({ productId: x.productId, qty: x.qty })),
-          couponCode: cart.coupon?.code || null,
-        }),
-      });
-      const raw = await res.text();
-      const data = raw ? JSON.parse(raw) : null;
-      if (!res.ok || !data?.ok) throw new Error(data?.error || "Preview failed");
-      setPreview(data);
-    } catch (e) {
-      setErr(String(e.message || e));
-    } finally {
-      setLoadingPreview(false);
+  useEffect(() => {
+    if (order?.orderPreview?.total != null) {
+      setTransferAmount(Number(order.orderPreview.total || 0).toFixed(2));
+      setReference("");
+    } else {
+      setTransferAmount("");
+      setReference("");
     }
-  }
+  }, [order]);
 
-  // --- สร้างออเดอร์จริง ---
+  const methodLocked = Boolean(order);
+  const needsPayment = (order?.orderPreview?.total || 0) > 0;
+
   async function placeOrder() {
-    if (!isFormValid) {
+    if (cart.items.length === 0) {
+      setErr("ตะกร้าว่างเปล่า");
+      return;
+    }
+
+    if (!isFormValid(form)) {
       setErr("กรุณากรอกข้อมูลที่จำเป็นให้ครบถ้วน");
       return;
     }
 
     setErr("");
-    setPlaced(null);
+    setCreating(true);
+    setOrder(null);
+    setSlipData("");
+    setSlipName("");
+    setTransferAmount("");
+    setReference("");
+
     try {
-      setLoadingPlace(true);
       const res = await fetch("/api/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          method: "promptpay",
+          method: paymentMethod,
           items: cart.items.map((x) => ({ productId: x.productId, qty: x.qty })),
           couponCode: cart.coupon?.code || null,
           customer: { name: form.name, phone: form.phone, email: form.email },
@@ -95,129 +114,319 @@ export default function CheckoutPage() {
       const raw = await res.text();
       const data = raw ? JSON.parse(raw) : null;
       if (!res.ok || !data?.ok) throw new Error(data?.error || "Checkout failed");
-      setPlaced(data);
-      // cart.clear(); // ถ้าต้องการล้างตะกร้าทันที
+      setOrder(data);
+      setPaymentMethod(data.method || paymentMethod);
     } catch (e) {
       setErr(String(e.message || e));
     } finally {
-      setLoadingPlace(false);
+      setCreating(false);
+    }
+  }
+
+  async function handleSlipChange(event) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      setSlipData("");
+      setSlipName("");
+      return;
+    }
+
+    if (!file.type?.startsWith("image/")) {
+      setErr("รองรับเฉพาะไฟล์รูปภาพเท่านั้น");
+      event.target.value = "";
+      return;
+    }
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      if (typeof dataUrl !== "string") throw new Error("ไม่สามารถอ่านไฟล์ได้");
+      setSlipData(dataUrl);
+      setSlipName(file.name || "สลิปการโอน");
+      setErr("");
+    } catch (e) {
+      setErr(String(e.message || e));
+      setSlipData("");
+      setSlipName("");
+      event.target.value = "";
+    }
+  }
+
+  async function confirmPayment() {
+    if (!order?.orderId) {
+      setErr("ยังไม่มีคำสั่งซื้อให้ยืนยัน");
+      return;
+    }
+    if (!slipData) {
+      setErr("กรุณาแนบสลิปการโอนก่อนยืนยัน");
+      return;
+    }
+
+    if (needsPayment && !transferAmount) {
+      setErr("กรุณากรอกจำนวนเงินที่โอน");
+      return;
+    }
+
+    setErr("");
+    setConfirming(true);
+
+    try {
+      const res = await fetch(`/api/orders/${order.orderId}/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          slip: slipData,
+          filename: slipName,
+          amount: transferAmount,
+          reference,
+        }),
+      });
+      const raw = await res.text();
+      const data = raw ? JSON.parse(raw) : null;
+      if (!res.ok || !data?.ok) throw new Error(data?.error || "ไม่สามารถยืนยันการชำระเงินได้");
+
+      cart.clear();
+      router.push(`/hook?order=${order.orderId}`);
+    } catch (e) {
+      setErr(String(e.message || e));
+    } finally {
+      setConfirming(false);
     }
   }
 
   return (
-    <main className="max-w-5xl mx-auto px-6 py-10 grid md:grid-cols-2 gap-6">
-      {/* ซ้าย: ฟอร์มผู้รับ */}
-      <section className="border rounded-2xl p-6 space-y-4">
-        <h1 className="text-2xl font-bold">Checkout</h1>
+    <main className="relative min-h-screen overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe1ea] via-[#fff7f0] to-[#ffe9d6]" />
+      <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[#f06583]/20 blur-3xl" />
+      <div className="absolute -bottom-28 right-10 h-72 w-72 rounded-full bg-[#f6c34a]/25 blur-3xl" />
 
-        <div className="grid grid-cols-1 gap-3">
-          {[
-            ["name", "ชื่อ-นามสกุล *"],
-            ["phone", "เบอร์โทร *"],
-            ["email", "อีเมล *"],
-            ["address1", "ที่อยู่ *"],
-            ["address2", "ที่อยู่ (บรรทัด 2)"],
-            ["district", "เขต/อำเภอ"],
-            ["province", "จังหวัด *"],
-            ["postcode", "รหัสไปรษณีย์ *"],
-            ["note", "หมายเหตุถึงร้าน"],
-          ].map(([key, label]) => (
-            <div key={key}>
-              <label className="text-sm block mb-1">{label}</label>
-              <input
-                className={`w-full border rounded px-3 py-2 ${
-                  requiredFields.includes(key) && !form[key] ? "border-red-400" : ""
+      <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
+        <div className="max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--color-rose)]">ชำระเงิน</p>
+          <h1 className="mt-2 text-3xl font-bold text-[var(--color-rose-dark)]">รายละเอียดจัดส่ง &amp; ยืนยันการโอน</h1>
+          <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+            กรอกข้อมูลการจัดส่ง แล้วระบบจะสร้าง QR PromptPay พร้อมให้แนบสลิปยืนยัน เพื่อให้ทีมงานเริ่มจัดเตรียมสินค้าอย่างรวดเร็ว
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[1.5fr_1fr]">
+          <section className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[#f065831f] space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--color-choco)]">ข้อมูลผู้รับและที่อยู่</h2>
+              <p className="mt-1 text-xs text-[var(--color-choco)]/70">ช่องที่มีเครื่องหมาย * จำเป็นต้องกรอก</p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {["name", "phone", "email", "address1", "address2", "district", "province", "postcode", "note"].map((key) => (
+                <div key={key} className={key === "note" ? "sm:col-span-2" : key === "address1" ? "sm:col-span-2" : ""}>
+                  <label className="mb-1 block text-sm font-medium">
+                    {key === "name"
+                      ? "ชื่อ-นามสกุล *"
+                      : key === "phone"
+                      ? "เบอร์โทร *"
+                      : key === "email"
+                      ? "อีเมล *"
+                      : key === "address1"
+                      ? "ที่อยู่ (บรรทัด 1) *"
+                      : key === "address2"
+                      ? "ที่อยู่ (บรรทัด 2)"
+                      : key === "district"
+                      ? "เขต/อำเภอ"
+                      : key === "province"
+                      ? "จังหวัด *"
+                      : key === "postcode"
+                      ? "รหัสไปรษณีย์ *"
+                      : "หมายเหตุถึงร้าน"}
+                  </label>
+                  <input
+                    className={`w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30 ${
+                      REQUIRED_FIELDS.includes(key) && !form[key] ? "border-rose-300" : ""
+                    }`}
+                    value={form[key]}
+                    onChange={(e) => setForm((f) => ({ ...f, [key]: e.target.value }))}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-4 pt-4 border-t border-[#f7b267]/40">
+              <div>
+                <h3 className="text-lg font-semibold text-[var(--color-choco)]">เลือกวิธีการชำระเงิน</h3>
+                <p className="mt-1 text-xs text-[var(--color-choco)]/70">
+                  รองรับทั้งการโอนผ่าน PromptPay และการโอนเข้าบัญชีธนาคาร พร้อมแนบสลิปเพื่อให้ระบบตรวจสอบยอดให้อัตโนมัติ
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {[{ value: "promptpay", label: "PromptPay QR", description: "สแกนจ่ายได้ทันที" }, { value: "bank", label: "โอนผ่านบัญชี", description: "โอนเข้าบัญชีธนาคาร" }].map((option) => {
+                  const active = paymentMethod === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => !methodLocked && setPaymentMethod(option.value)}
+                      disabled={methodLocked && !active}
+                      className={`rounded-2xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-[#f06583]/40 ${
+                        active
+                          ? "border-[#f06583] bg-[#fff4f7] text-[var(--color-rose-dark)] shadow"
+                          : "border-[#f7b267]/60 bg-white text-[var(--color-choco)]/80"
+                      } ${methodLocked && !active ? "opacity-50 cursor-not-allowed" : ""}`}
+                    >
+                      <div className="text-sm font-semibold">{option.label}</div>
+                      <div className="mt-1 text-xs text-[var(--color-choco)]/70">{option.description}</div>
+                    </button>
+                  );
+                })}
+              </div>
+              {methodLocked ? (
+                <p className="text-xs text-[var(--color-choco)]/60">
+                  หากต้องการเปลี่ยนวิธีการชำระเงิน ให้แก้ไขรายละเอียดแล้วกดสร้างคำสั่งซื้อใหม่
+                </p>
+              ) : null}
+
+              <button
+                onClick={placeOrder}
+                disabled={creating || cart.items.length === 0}
+                className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition ${
+                  creating || cart.items.length === 0
+                    ? "bg-[#f3b6c7] cursor-not-allowed"
+                    : "bg-gradient-to-r from-[#f06583] to-[#f78da7] hover:shadow-xl"
                 }`}
-                value={form[key]}
-                onChange={(e) => setForm((f) => ({ ...f, [key]: e.target.value }))}
-              />
+              >
+                {creating
+                  ? "กำลังสร้างคำสั่งซื้อ..."
+                  : paymentMethod === "bank"
+                  ? "สร้างคำสั่งซื้อเพื่อโอน"
+                  : "สร้างคำสั่งซื้อและ QR"}
+              </button>
             </div>
-          ))}
+
+            {err && !order && <div className="text-sm text-rose-600">{err}</div>}
+          </section>
+
+          <section className="space-y-6">
+            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[#f065831a]">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">สรุปรายการ</h2>
+              <div className="mt-4 space-y-3 text-sm">
+                {currentTotals.items.map((it) => (
+                  <div key={`${it.productId}-${it.title}`} className="flex justify-between">
+                    <span>
+                      {it.title} × {it.qty}
+                    </span>
+                    <span>฿{fmt(it.lineTotal ?? (it.price || 0) * it.qty)}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 space-y-2 border-t border-[#f7b267]/40 pt-4 text-sm">
+                <div className="flex justify-between text-[var(--color-choco)]/80">
+                  <span>รวม</span>
+                  <span>฿{fmt(currentTotals.subtotal)}</span>
+                </div>
+                {currentTotals.discount ? (
+                  <div className="flex justify-between text-emerald-600">
+                    <span>
+                      คูปอง {currentTotals.coupon?.code}
+                      {currentTotals.coupon?.description ? ` (${currentTotals.coupon.description})` : ""}
+                    </span>
+                    <span>-฿{fmt(currentTotals.discount)}</span>
+                  </div>
+                ) : null}
+                <div className="flex justify-between text-base font-semibold text-[var(--color-rose-dark)]">
+                  <span>ยอดสุทธิ</span>
+                  <span>฿{fmt(currentTotals.total)}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[#f065831a] space-y-4">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">ยืนยันการโอน</h2>
+              {order ? (
+                <div className="space-y-4">
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+                    สร้างคำสั่งซื้อ #{order.orderId} แล้ว กรุณาชำระเงินและแนบสลิปเพื่อยืนยัน ระบบจะตรวจสอบยอดที่ชำระให้อัตโนมัติ
+                  </div>
+                  {order.promptpay ? (
+                    <QrBox
+                      payload={order.promptpay.payload}
+                      amount={order.orderPreview.total}
+                      title="สแกนเพื่อชำระเงิน"
+                    />
+                  ) : paymentMethod === "bank" && order.bankAccount ? (
+                    <div className="space-y-3 rounded-2xl border border-[#f7b267]/50 bg-[#fff8f1] p-4 text-sm text-[var(--color-choco)]">
+                      <div className="font-semibold text-[var(--color-rose-dark)]">รายละเอียดบัญชีสำหรับโอน</div>
+                      <div>ธนาคาร: {order.bankAccount.bank}</div>
+                      <div>เลขบัญชี: {order.bankAccount.number}</div>
+                      <div>ชื่อบัญชี: {order.bankAccount.name}</div>
+                      {order.bankAccount.promptpayId ? (
+                        <div className="text-xs text-[var(--color-choco)]/70">
+                          หรือโอนผ่าน PromptPay ID: {order.bankAccount.promptpayId}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <div className="text-sm text-[var(--color-choco)]/70">ออเดอร์นี้ไม่ต้องชำระเงินเพิ่มเติม</div>
+                  )}
+
+                  {needsPayment ? (
+                    <div className="space-y-2 text-sm">
+                      <label className="font-medium">จำนวนเงินที่โอน (บาท) *</label>
+                      <input
+                        type="text"
+                        value={transferAmount}
+                        onChange={(e) => setTransferAmount(e.target.value)}
+                        className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                        placeholder={`ยอดที่ต้องชำระ ฿${fmt(order.orderPreview.total)}`}
+                      />
+                      <p className="text-xs text-[var(--color-choco)]/60">ยอดที่ต้องชำระทั้งหมด ฿{fmt(order.orderPreview.total)}</p>
+                    </div>
+                  ) : (
+                    <div className="rounded-2xl border border-[#f7b267]/40 bg-[#fff9f4] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                      ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
+                    </div>
+                  )}
+
+                  <div className="space-y-2 text-sm">
+                    <label className="font-medium">หมายเลขอ้างอิงการโอน (ถ้ามี)</label>
+                    <input
+                      type="text"
+                      value={reference}
+                      onChange={(e) => setReference(e.target.value)}
+                      className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                      placeholder="เช่น เลขที่รายการ หรือเลขอ้างอิงจากแอปธนาคาร"
+                    />
+                  </div>
+
+                  <div className="space-y-2 text-sm">
+                    <label className="font-medium">แนบสลิปการโอน *</label>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      onChange={handleSlipChange}
+                      className="text-sm"
+                    />
+                    {slipName && <div className="text-xs text-[var(--color-choco)]/60">ไฟล์: {slipName}</div>}
+                  </div>
+                  <button
+                    onClick={confirmPayment}
+                    disabled={confirming || !slipData || (needsPayment && !transferAmount)}
+                    className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition ${
+                      confirming || !slipData || (needsPayment && !transferAmount)
+                        ? "bg-[#f3b6c7] cursor-not-allowed"
+                        : "bg-gradient-to-r from-[#f06583] to-[#f6c34a] hover:shadow-xl"
+                    }`}
+                  >
+                    {confirming ? "กำลังยืนยัน..." : "ยืนยันการชำระเงิน"}
+                  </button>
+                </div>
+              ) : (
+                <div className="text-sm text-[var(--color-choco)]/70">
+                  กดปุ่ม "สร้าง QR สำหรับชำระเงิน" เพื่อสร้างคำสั่งซื้อและรับ QR PromptPay
+                </div>
+              )}
+              {err && order && <div className="text-sm text-rose-600">{err}</div>}
+            </div>
+          </section>
         </div>
-
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={doPreview}
-            disabled={loadingPreview || cart.items.length === 0}
-            className="px-4 py-2 rounded border"
-          >
-            {loadingPreview ? "กำลังพรีวิว..." : "ดู QR (พรีวิว)"}
-          </button>
-
-          <button
-            onClick={placeOrder}
-            disabled={loadingPlace || cart.items.length === 0 || !isFormValid}
-            className={`px-4 py-2 rounded text-white ${
-              !isFormValid || loadingPlace || cart.items.length === 0
-                ? "bg-gray-400 cursor-not-allowed"
-                : "bg-black"
-            }`}
-          >
-            {loadingPlace ? "กำลังสร้างคำสั่งซื้อ..." : "ยืนยันสั่งซื้อ"}
-          </button>
-        </div>
-
-        {err && <div className="text-sm text-red-600">{err}</div>}
-      </section>
-
-      {/* ขวา: สรุปรายการ + QR */}
-      <section className="border rounded-2xl p-6 space-y-3">
-        <h2 className="text-xl font-semibold">สรุปรายการ</h2>
-
-        <div className="space-y-2">
-          {cart.items.map((it) => (
-            <div key={it.productId} className="flex justify-between">
-              <span>
-                {it.title} × {it.qty}
-              </span>
-              <span>฿{fmt(it.price * it.qty)}</span>
-            </div>
-          ))}
-        </div>
-
-        <div className="pt-2 space-y-1">
-          <div className="flex justify-between">
-            <span>รวม</span>
-            <span>฿{fmt(cart.subtotal)}</span>
-          </div>
-          {cart.coupon?.discount ? (
-            <div className="flex justify-between text-green-700">
-              <span>
-                คูปอง {cart.coupon.code} ({cart.coupon.description})
-              </span>
-              <span>-฿{fmt(cart.coupon.discount)}</span>
-            </div>
-          ) : null}
-        </div>
-
-        {/* พรีวิว */}
-        {/* {preview && (
-          <div className="mt-3">
-            <div className="font-medium mb-2">
-              พรีวิวยอดสุทธิ: ฿{fmt(preview.orderPreview.total)}
-            </div>
-            <QrBox
-              payload={preview.promptpay?.payload}
-              amount={preview.orderPreview.total}
-              title="สแกนทดสอบ (พรีวิว)"
-            />
-          </div>
-        )} */}
-
-        {/* ออเดอร์จริง */}
-        {placed && (
-          <div className="mt-3">
-            <div className="font-medium mb-2">
-              สร้างออเดอร์แล้ว #{placed.orderId} — ยอดสุทธิ: ฿{fmt(placed.orderPreview.total)}
-            </div>
-            <QrBox
-              payload={placed.promptpay?.payload}
-              amount={placed.orderPreview.total}
-              title="สแกนเพื่อชำระเงินจริง"
-            />
-          </div>
-        )}
-      </section>
+      </div>
     </main>
   );
 }

--- a/app/(site)/hook/page.jsx
+++ b/app/(site)/hook/page.jsx
@@ -30,6 +30,12 @@ export default function HookPage({ searchParams }) {
           >
             กลับสู่หน้าหลัก
           </Link>
+          <Link
+            href="/orders"
+            className="mt-4 inline-flex items-center justify-center rounded-full border border-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+          >
+            ดูคำสั่งซื้อของฉัน
+          </Link>
         </div>
       </div>
     </main>

--- a/app/(site)/hook/page.jsx
+++ b/app/(site)/hook/page.jsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+export default function HookPage({ searchParams }) {
+  const orderId = searchParams?.order ? String(searchParams.order) : "";
+
+  return (
+    <main className="relative min-h-[70vh] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ecfdf5] via-[#fff] to-[#ffe9f2]" />
+      <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#f6c34a]/25 blur-3xl" />
+      <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[#f06583]/15 blur-3xl" />
+
+      <div className="relative flex items-center justify-center px-6 py-20">
+        <div className="max-w-lg w-full rounded-3xl bg-white/95 p-10 text-center shadow-2xl shadow-[#f0658320]">
+          <div className="space-y-3">
+            <span className="inline-flex items-center gap-2 rounded-full bg-[#ecfdf5] px-4 py-2 text-xs font-semibold text-emerald-600">
+              ✅ การสั่งซื้อสำเร็จ
+            </span>
+            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ขอบคุณที่สั่ง Sweet Cravings</h1>
+            <p className="text-sm text-[var(--color-choco)]/70">
+              เราได้รับสลิปและยืนยันการชำระเงินเรียบร้อยแล้ว ทีมงานกำลังจัดเตรียมสินค้าเพื่อจัดส่งให้คุณโดยเร็วที่สุด
+            </p>
+            {orderId ? (
+              <p className="text-xs font-medium text-[var(--color-choco)]/60">รหัสคำสั่งซื้อของคุณ: {orderId}</p>
+            ) : null}
+          </div>
+
+          <Link
+            href="/"
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#f06583] to-[#f6c34a] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:shadow-xl"
+          >
+            กลับสู่หน้าหลัก
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(site)/login/page.js
+++ b/app/(site)/login/page.js
@@ -1,9 +1,10 @@
 "use client";
+import { Suspense, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { useState } from "react";
 import { signIn } from "next-auth/react";
+import Link from "next/link";
 
-export default function LoginPage() {
+function LoginContent() {
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState("");
   const sp = useSearchParams();
@@ -17,7 +18,6 @@ export default function LoginPage() {
     const email = form.get("email");
     const password = form.get("password");
 
-    // v4 way
     const res = await signIn("credentials", {
       redirect: false,
       email,
@@ -29,22 +29,78 @@ export default function LoginPage() {
       setErr("อีเมลหรือรหัสผ่านไม่ถูกต้อง");
       return;
     }
-    // ถ้า login ok ให้ไปหน้า redirect (หรือหน้าแรก)
     const to = sp.get("redirect") || "/";
     router.push(to);
   }
 
   return (
-    <main className="max-w-md mx-auto px-6 py-10">
-      <h1 className="text-2xl font-bold mb-6">Login</h1>
-      <form onSubmit={onSubmit} className="space-y-4">
-        <input name="email" type="email" placeholder="อีเมล" className="w-full border rounded px-3 py-2" required />
-        <input name="password" type="password" placeholder="รหัสผ่าน" className="w-full border rounded px-3 py-2" required />
-        <button disabled={loading} className="w-full bg-black text-white rounded py-2">
-          {loading ? "กำลังเข้าสู่ระบบ..." : "เข้าสู่ระบบ"}
-        </button>
-      </form>
-      {err && <p className="text-sm text-red-600 mt-4">{err}</p>}
+    <main className="relative min-h-[70vh] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe1ef] via-[#fff7f0] to-[#ffe6d4]" />
+      <div className="absolute -top-24 right-20 h-64 w-64 rounded-full bg-[#f06583]/20 blur-3xl" />
+      <div className="absolute -bottom-28 left-12 h-72 w-72 rounded-full bg-[#f6c34a]/25 blur-3xl" />
+
+      <div className="relative flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl bg-white/95 p-8 shadow-2xl shadow-[#f0658320]">
+          <div className="text-center">
+            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ยินดีต้อนรับกลับ</h1>
+            <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+              เข้าสู่ระบบเพื่อจัดการคำสั่งซื้อและดูสถานะการจัดส่งของคุณ
+            </p>
+          </div>
+
+          <form onSubmit={onSubmit} className="mt-8 space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium">อีเมล</label>
+              <input
+                name="email"
+                type="email"
+                placeholder="name@example.com"
+                className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">รหัสผ่าน</label>
+              <input
+                name="password"
+                type="password"
+                placeholder="รหัสผ่าน"
+                className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                required
+              />
+            </div>
+            <button
+              disabled={loading}
+              className="w-full rounded-full bg-gradient-to-r from-[#f06583] to-[#f78da7] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {loading ? "กำลังเข้าสู่ระบบ..." : "เข้าสู่ระบบ"}
+            </button>
+          </form>
+
+          {err && <p className="mt-4 text-sm text-rose-600">{err}</p>}
+
+          <p className="mt-6 text-center text-sm text-[var(--color-choco)]/70">
+            ยังไม่มีบัญชี?
+            <Link href="/register" className="ml-2 font-semibold text-[var(--color-rose)] hover:text-[var(--color-rose-dark)]">
+              สมัครสมาชิกเลย
+            </Link>
+          </p>
+        </div>
+      </div>
     </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-choco)]/70">
+          กำลังโหลดฟอร์มเข้าสู่ระบบ...
+        </main>
+      }
+    >
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/app/(site)/orders/[id]/page.jsx
+++ b/app/(site)/orders/[id]/page.jsx
@@ -1,7 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 
 export default function OrderDetailPage() {
   const params = useParams();
@@ -9,6 +10,8 @@ export default function OrderDetailPage() {
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
+  const [needsAuth, setNeedsAuth] = useState(false);
+  const { status } = useSession();
 
   useEffect(() => {
     if (!id) return;
@@ -16,6 +19,10 @@ export default function OrderDetailPage() {
       try {
         const res = await fetch(`/api/my/orders/${id}`, { cache: "no-store" });
         const data = await res.json();
+        if (res.status === 401) {
+          setNeedsAuth(true);
+          return;
+        }
         if (!res.ok) throw new Error(data?.error || "Load order failed");
         setOrder(data);
       } catch (e) {
@@ -26,47 +33,212 @@ export default function OrderDetailPage() {
     })();
   }, [id]);
 
-  if (loading) return <main className="max-w-3xl mx-auto px-6 py-10">กำลังโหลด...</main>;
-  if (err) return <main className="max-w-3xl mx-auto px-6 py-10 text-red-600">{err}</main>;
+  const statusLabel = useMemo(
+    () => ({
+      new: "รอจัดเตรียม",
+      preparing: "กำลังจัดเตรียม",
+      shipped: "กำลังจัดส่ง",
+      done: "จัดส่งสำเร็จ",
+      cancelled: "ยกเลิก",
+    }),
+    []
+  );
+
+  const paymentLabel = useMemo(
+    () => ({
+      pending: "รอยืนยัน",
+      paid: "ชำระแล้ว",
+      failed: "ไม่สำเร็จ",
+    }),
+    []
+  );
+
+  if (loading)
+    return <main className="max-w-3xl mx-auto px-6 py-10 text-[var(--color-choco)]/70">กำลังโหลด...</main>;
+
+  if (needsAuth && status !== "loading") {
+    return (
+      <main className="relative min-h-[70vh] overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-[#ffe9f2] via-[#fff7f0] to-[#ffe1d0]" />
+        <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
+          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[#f0658320]">
+            <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบก่อนดูรายละเอียด</h1>
+            <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+              โปรดเข้าสู่ระบบเพื่อยืนยันตัวตนก่อนเข้าถึงรายละเอียดคำสั่งซื้อ
+            </p>
+            <div className="mt-6 flex flex-col gap-3">
+              <Link
+                href="/login"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
+              >
+                เข้าสู่ระบบ
+              </Link>
+              <Link
+                href="/register"
+                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+              >
+                สมัครสมาชิกใหม่
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (err) return <main className="max-w-3xl mx-auto px-6 py-10 text-rose-600">{err}</main>;
   if (!order) return null;
 
   return (
-    <main className="max-w-3xl mx-auto px-6 py-10">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Order #{order._id.slice(-8)}</h1>
-        <Link href="/orders" className="underline">กลับรายการทั้งหมด</Link>
-      </div>
+    <main className="relative min-h-[70vh] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe9f2] via-[#fff7f0] to-[#ffe1d0]" />
+      <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[#f06583]/15 blur-3xl" />
+      <div className="absolute -bottom-20 left-20 h-72 w-72 rounded-full bg-[#f6c34a]/20 blur-3xl" />
 
-      <div className="grid md:grid-cols-2 gap-4">
-        <div className="border rounded-xl p-4">
-          <div className="font-semibold mb-2">รายการสินค้า</div>
-          <div className="space-y-2">
+      <div className="relative max-w-4xl mx-auto px-6 py-16">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">
+              คำสั่งซื้อ #{(order.id || order._id).slice(-8)}
+            </h1>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              อัปเดตล่าสุดเมื่อ {order.updatedAt ? new Date(order.updatedAt).toLocaleString() : "-"}
+            </p>
+          </div>
+          <Link
+            href="/orders"
+            className="inline-flex items-center justify-center rounded-full bg-white/80 px-5 py-2 text-sm font-semibold text-[var(--color-rose-dark)] shadow hover:bg-white"
+          >
+            ← กลับไปหน้ารายการทั้งหมด
+          </Link>
+        </div>
+
+        <div className="mt-10 grid gap-6 lg:grid-cols-[1.3fr_1fr]">
+          <section className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f0658315]">
+            <header className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">สถานะคำสั่งซื้อ</h2>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                  order.status === "cancelled"
+                    ? "bg-rose-100 text-rose-600"
+                    : order.status === "done"
+                    ? "bg-emerald-100 text-emerald-600"
+                    : "bg-[#ecfdf5] text-emerald-600"
+                }`}
+              >
+                {statusLabel[order.status] || order.status}
+              </span>
+            </header>
+            <div className="mt-4 grid gap-3 text-sm text-[var(--color-choco)]/80">
+              <div className="flex items-center justify-between rounded-2xl bg-[#fff6ee] px-4 py-3">
+                <span>การชำระเงิน</span>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    order.payment?.status === "paid"
+                      ? "bg-emerald-100 text-emerald-600"
+                      : order.payment?.status === "failed"
+                      ? "bg-rose-100 text-rose-600"
+                      : "bg-amber-100 text-amber-600"
+                  }`}
+                >
+                  {paymentLabel[order.payment?.status] || order.payment?.status}
+                </span>
+              </div>
+              <div className="flex items-center justify-between rounded-2xl bg-[#fef9ff] px-4 py-3">
+                <span>ช่องทาง</span>
+                <span className="font-medium text-[var(--color-rose-dark)]">
+                  {order.payment?.method === "bank" ? "โอนผ่านธนาคาร" : "พร้อมเพย์"}
+                </span>
+              </div>
+              {typeof order.payment?.amountPaid === "number" ? (
+                <div className="flex items-center justify-between rounded-2xl bg-[#ecfdf5] px-4 py-3">
+                  <span>จำนวนที่โอน</span>
+                  <span className="font-semibold text-emerald-600">฿{order.payment.amountPaid.toFixed(2)}</span>
+                </div>
+              ) : null}
+              {order.payment?.confirmedAt ? (
+                <div className="flex items-center justify-between rounded-2xl bg-white px-4 py-3">
+                  <span>ยืนยันเมื่อ</span>
+                  <span>{new Date(order.payment.confirmedAt).toLocaleString()}</span>
+                </div>
+              ) : null}
+            </div>
+
+            {order.payment?.slip ? (
+              <div className="mt-6">
+                <h3 className="text-sm font-semibold text-[var(--color-choco)]">สลิปการโอน</h3>
+                <div className="mt-3 overflow-hidden rounded-2xl border border-white/60 shadow-inner">
+                  <img
+                    src={order.payment.slip}
+                    alt={order.payment.slipFilename || "หลักฐานการโอน"}
+                    className="max-h-[420px] w-full object-contain bg-white"
+                  />
+                </div>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="space-y-6">
+            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f0658315]">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายละเอียดยอดชำระ</h2>
+              <div className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
+                <div className="flex justify-between">
+                  <span>รวม</span>
+                  <span>฿{order.subtotal}</span>
+                </div>
+                {order.discount ? (
+                  <div className="flex justify-between text-emerald-600">
+                    <span>ส่วนลด</span>
+                    <span>-฿{order.discount}</span>
+                  </div>
+                ) : null}
+                <div className="flex justify-between text-base font-semibold text-[var(--color-rose-dark)]">
+                  <span>ยอดสุทธิ</span>
+                  <span>฿{order.total}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f0658315]">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">ข้อมูลจัดส่ง</h2>
+              <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/80">
+                <div>
+                  <div className="font-semibold">{order.customer?.name || "-"}</div>
+                  <div>{order.customer?.phone || ""}</div>
+                  <div>{order.customer?.email || ""}</div>
+                </div>
+                <div className="rounded-2xl bg-[#fff6ee] p-4 text-sm leading-relaxed">
+                  <p>{order.shipping?.address1}</p>
+                  {order.shipping?.address2 ? <p>{order.shipping.address2}</p> : null}
+                  <p>
+                    {order.shipping?.district || ""} {order.shipping?.province || ""} {order.shipping?.postcode || ""}
+                  </p>
+                  {order.shipping?.note ? (
+                    <p className="mt-2 text-xs text-[var(--color-choco)]/60">หมายเหตุ: {order.shipping.note}</p>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f0658315]">
+          <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
+          <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
             {order.items.map((it, idx) => (
-              <div key={`${order._id}-${it.productId || it.title}-${idx}`} className="flex justify-between">
-                <span>{it.title} × {it.qty}</span>
-                <span>฿{it.price * it.qty}</span>
+              <div
+                key={`${order.id || order._id}-${it.productId || it.title}-${idx}`}
+                className="flex flex-col gap-2 py-4 text-sm text-[var(--color-choco)]/80 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <div className="font-medium text-[var(--color-choco)]">{it.title}</div>
+                  <div className="text-xs text-[var(--color-choco)]/60">จำนวน {it.qty}</div>
+                </div>
+                <div className="text-sm font-semibold text-[var(--color-rose-dark)]">฿{(it.price || 0) * (it.qty || 0)}</div>
               </div>
             ))}
           </div>
-        </div>
-
-        <div className="border rounded-xl p-4">
-          <div className="font-semibold mb-2">สรุปยอด</div>
-          <div className="flex justify-between"><span>รวม</span><span>฿{order.subtotal}</span></div>
-          {order.discount ? (
-            <div className="flex justify-between text-green-700">
-              <span>ส่วนลด</span><span>-฿{order.discount}</span>
-            </div>
-          ) : null}
-          <div className="flex justify-between font-semibold mt-2">
-            <span>สุทธิ</span><span>฿{order.total}</span>
-          </div>
-          <div className="text-sm text-gray-600 mt-3">
-            สถานะคำสั่งซื้อ: <span className="font-medium">{order.status}</span><br/>
-            การชำระเงิน: <span className="font-medium">{order.payment?.method} / {order.payment?.status}</span><br/>
-            เวลา: {new Date(order.createdAt).toLocaleString()}
-          </div>
-        </div>
+        </section>
       </div>
     </main>
   );

--- a/app/(site)/orders/page.jsx
+++ b/app/(site)/orders/page.jsx
@@ -22,48 +22,99 @@ export default function OrdersPage() {
     })();
   }, []);
 
-  if (loading) return <main className="max-w-4xl mx-auto px-6 py-10">กำลังโหลด...</main>;
-  if (err) return <main className="max-w-4xl mx-auto px-6 py-10 text-red-600">{err}</main>;
+  if (loading)
+    return (
+      <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-choco)]/70">
+        กำลังโหลด...
+      </main>
+    );
+  if (err)
+    return (
+      <main className="flex min-h-[60vh] items-center justify-center text-rose-600">
+        {err}
+      </main>
+    );
 
   return (
-    <main className="max-w-4xl mx-auto px-6 py-10">
-      <h1 className="text-2xl font-bold mb-6">คำสั่งซื้อของฉัน</h1>
+    <main className="relative min-h-[70vh] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe9f2] via-[#fff7f0] to-[#ffe1d0]" />
+      <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[#f06583]/15 blur-3xl" />
+      <div className="absolute -bottom-20 left-12 h-72 w-72 rounded-full bg-[#f6c34a]/20 blur-3xl" />
 
-      {orders.length === 0 ? (
-        <div className="border rounded-xl p-6 text-gray-600">
-          ยังไม่มีคำสั่งซื้อ — <Link href="/" className="underline">เลือกสินค้า</Link>
+      <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">คำสั่งซื้อของฉัน</h1>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              ติดตามสถานะคำสั่งซื้อและดูรายละเอียดการชำระเงินย้อนหลังได้ที่นี่
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
+          >
+            เลือกสินค้าเพิ่ม
+          </Link>
         </div>
-      ) : (
-        <div className="space-y-3">
-          {orders.map((o) => (
-            <Link
-              href={`/orders/${o._id}`}
-              key={o._id}
-              className="block border rounded-xl p-4 hover:bg-gray-50"
-            >
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="font-semibold">Order #{o._id.slice(-8)}</div>
-                  <div className="text-xs text-gray-500">
-                    {new Date(o.createdAt).toLocaleString()}
+
+        {orders.length === 0 ? (
+          <div className="mt-10 rounded-3xl bg-white/85 p-10 text-center shadow-lg shadow-[#f0658322]">
+            <p className="text-lg font-semibold text-[var(--color-choco)]">
+              ยังไม่มีคำสั่งซื้อ
+            </p>
+            <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+              เริ่มต้นสั่งขนมแสนอร่อยได้เลยที่
+              <Link href="/" className="ml-1 underline">
+                หน้าหลัก
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <div className="mt-10 grid gap-6 sm:grid-cols-2">
+            {orders.map((o) => (
+              <Link
+                href={`/orders/${o._id}`}
+                key={o._id}
+                className="group block rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f065831a] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm uppercase tracking-[0.2em] text-[var(--color-rose)]">Order</div>
+                    <div className="text-xl font-semibold text-[var(--color-choco)]">
+                      #{o._id.slice(-8)}
+                    </div>
+                  </div>
+                  <span className="rounded-full bg-[#fff1dd] px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/80">
+                    {new Date(o.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
+
+                <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/70">
+                  <div className="flex items-center justify-between">
+                    <span>ยอดสุทธิ</span>
+                    <span className="font-semibold text-[var(--color-rose-dark)]">฿{o.total}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>สถานะ</span>
+                    <span className="rounded-full bg-[#ecfdf5] px-3 py-1 text-xs font-semibold text-emerald-600">
+                      {o.status}
+                    </span>
                   </div>
                 </div>
-                <div className="text-right">
-                  <div className="font-semibold">฿{o.total}</div>
-                  <div className="text-xs text-gray-500">{o.status}</div>
+
+                <div className="mt-4 line-clamp-2 text-xs text-[var(--color-choco)]/60">
+                  {o.items.map((it, idx) => (
+                    <span key={`${o._id}-${it.productId || it.title}-${idx}`}>
+                      {it.title} × {it.qty}
+                      {idx < o.items.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
                 </div>
-              </div>
-              <div className="text-sm text-gray-600 mt-2 line-clamp-1">
-                {o.items.map((it, idx) => (
-                  <span key={`${o._id}-${it.productId || it.title}-${idx}`}>
-                    {it.title} × {it.qty}{idx < o.items.length - 1 ? ", " : ""}
-                  </span>
-                ))}
-              </div>
-            </Link>
-          ))}
-        </div>
-      )}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/app/(site)/orders/page.jsx
+++ b/app/(site)/orders/page.jsx
@@ -1,17 +1,24 @@
 "use client";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
+import { useSession } from "next-auth/react";
 
 export default function OrdersPage() {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
+  const [needsAuth, setNeedsAuth] = useState(false);
+  const { status } = useSession();
 
   useEffect(() => {
     (async () => {
       try {
         const res = await fetch("/api/my/orders", { cache: "no-store" });
         const data = await res.json();
+        if (res.status === 401) {
+          setNeedsAuth(true);
+          return;
+        }
         if (!res.ok) throw new Error(data?.error || "Load orders failed");
         setOrders(data);
       } catch (e) {
@@ -22,12 +29,63 @@ export default function OrdersPage() {
     })();
   }, []);
 
+  const statusLabel = useMemo(
+    () => ({
+      new: "รอจัดเตรียม",
+      preparing: "กำลังจัดเตรียม",
+      shipped: "กำลังจัดส่ง",
+      done: "จัดส่งสำเร็จ",
+      cancelled: "ยกเลิก",
+    }),
+    []
+  );
+
+  const paymentLabel = useMemo(
+    () => ({
+      pending: "รอยืนยัน",
+      paid: "ชำระแล้ว",
+      failed: "ไม่สำเร็จ",
+    }),
+    []
+  );
+
   if (loading)
     return (
       <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-choco)]/70">
         กำลังโหลด...
       </main>
     );
+
+  if (needsAuth && status !== "loading") {
+    return (
+      <main className="relative min-h-[70vh] overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-[#ffe9f2] via-[#fff7f0] to-[#ffe1d0]" />
+        <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
+          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[#f0658320]">
+            <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบเพื่อดูคำสั่งซื้อ</h1>
+            <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+              บัญชีผู้ใช้จำเป็นสำหรับเชื่อมคำสั่งซื้อกับคุณ กรุณาเข้าสู่ระบบหรือสมัครสมาชิกใหม่เพื่อดูประวัติการสั่งซื้อทั้งหมดของคุณ
+            </p>
+            <div className="mt-6 flex flex-col gap-3">
+              <Link
+                href="/login"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
+              >
+                เข้าสู่ระบบ
+              </Link>
+              <Link
+                href="/register"
+                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+              >
+                สมัครสมาชิกใหม่
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
   if (err)
     return (
       <main className="flex min-h-[60vh] items-center justify-center text-rose-600">
@@ -71,47 +129,77 @@ export default function OrdersPage() {
           </div>
         ) : (
           <div className="mt-10 grid gap-6 sm:grid-cols-2">
-            {orders.map((o) => (
-              <Link
-                href={`/orders/${o._id}`}
-                key={o._id}
-                className="group block rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f065831a] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="text-sm uppercase tracking-[0.2em] text-[var(--color-rose)]">Order</div>
-                    <div className="text-xl font-semibold text-[var(--color-choco)]">
-                      #{o._id.slice(-8)}
+            {orders.map((o) => {
+              const orderId = o?.id || o?._id || "";
+              const createdAt = o?.createdAt ? new Date(o.createdAt) : null;
+              const paymentStatus = o?.payment?.status || "pending";
+              const displayPayment = paymentLabel[paymentStatus] || paymentStatus;
+              const displayStatus = statusLabel[o?.status] || o?.status;
+
+              return (
+                <Link
+                  href={`/orders/${orderId}`}
+                  key={orderId}
+                  className="group block rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f065831a] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm uppercase tracking-[0.2em] text-[var(--color-rose)]">Order</div>
+                      <div className="text-xl font-semibold text-[var(--color-choco)]">
+                        #{orderId.slice(-8)}
+                      </div>
+                    </div>
+                    <span className="rounded-full bg-[#fff1dd] px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/80">
+                      {createdAt ? createdAt.toLocaleDateString() : "-"}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/70">
+                    <div className="flex items-center justify-between">
+                      <span>ยอดสุทธิ</span>
+                      <span className="font-semibold text-[var(--color-rose-dark)]">฿{o.total}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>สถานะ</span>
+                      <span
+                        className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                          o.status === "cancelled"
+                            ? "bg-rose-100 text-rose-600"
+                            : o.status === "done"
+                            ? "bg-emerald-100 text-emerald-600"
+                            : "bg-[#ecfdf5] text-emerald-600"
+                        }`}
+                      >
+                        {displayStatus}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between text-xs">
+                      <span>การชำระเงิน</span>
+                      <span
+                        className={`rounded-full px-2 py-1 font-semibold ${
+                          paymentStatus === "paid"
+                            ? "bg-emerald-100 text-emerald-600"
+                            : paymentStatus === "failed"
+                            ? "bg-rose-100 text-rose-600"
+                            : "bg-amber-100 text-amber-600"
+                        }`}
+                      >
+                        {displayPayment}
+                      </span>
                     </div>
                   </div>
-                  <span className="rounded-full bg-[#fff1dd] px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/80">
-                    {new Date(o.createdAt).toLocaleDateString()}
-                  </span>
-                </div>
 
-                <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/70">
-                  <div className="flex items-center justify-between">
-                    <span>ยอดสุทธิ</span>
-                    <span className="font-semibold text-[var(--color-rose-dark)]">฿{o.total}</span>
+                  <div className="mt-4 line-clamp-2 text-xs text-[var(--color-choco)]/60">
+                    {o.items.map((it, idx) => (
+                      <span key={`${orderId}-${it.productId || it.title}-${idx}`}>
+                        {it.title} × {it.qty}
+                        {idx < o.items.length - 1 ? ", " : ""}
+                      </span>
+                    ))}
                   </div>
-                  <div className="flex items-center justify-between">
-                    <span>สถานะ</span>
-                    <span className="rounded-full bg-[#ecfdf5] px-3 py-1 text-xs font-semibold text-emerald-600">
-                      {o.status}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="mt-4 line-clamp-2 text-xs text-[var(--color-choco)]/60">
-                  {o.items.map((it, idx) => (
-                    <span key={`${o._id}-${it.productId || it.title}-${idx}`}>
-                      {it.title} × {it.qty}
-                      {idx < o.items.length - 1 ? ", " : ""}
-                    </span>
-                  ))}
-                </div>
-              </Link>
-            ))}
+                </Link>
+              );
+            })}
           </div>
         )}
       </div>

--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -6,17 +6,19 @@ export default async function HomePage() {
   let products = [];
 
   try {
-    await connectToDatabase();
-    const docs = await Product.find({ active: true })
-      .sort({ createdAt: -1 })
-      .lean();
-    products = (docs || []).map((d) => ({
-      _id: String(d._id),
-      title: d.title || "",
-      description: d.description || "",
-      price: d.price ?? 0,
-      images: d.images || [],
-    }));
+    if (process.env.MONGODB_URI) {
+      await connectToDatabase();
+      const docs = await Product.find({ active: true })
+        .sort({ createdAt: -1 })
+        .lean();
+      products = (docs || []).map((d) => ({
+        _id: String(d._id),
+        title: d.title || "",
+        description: d.description || "",
+        price: d.price ?? 0,
+        images: d.images || [],
+      }));
+    }
   } catch (error) {
     console.error("โหลดสินค้าไม่สำเร็จ", error);
   }

--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -3,41 +3,160 @@ import { Product } from "@/models/Product";
 import AddToCartButton from "@/components/AddToCartButton";
 
 export default async function HomePage() {
-  await connectToDatabase();
-  const docs = await Product.find({ active: true })
-    .sort({ createdAt: -1 })
-    .lean();
-  const products = (docs || []).map((d) => ({
-    _id: String(d._id),
-    title: d.title || "",
-    description: d.description || "",
-    price: d.price ?? 0,
-  }));
+  let products = [];
+
+  try {
+    await connectToDatabase();
+    const docs = await Product.find({ active: true })
+      .sort({ createdAt: -1 })
+      .lean();
+    products = (docs || []).map((d) => ({
+      _id: String(d._id),
+      title: d.title || "",
+      description: d.description || "",
+      price: d.price ?? 0,
+      images: d.images || [],
+    }));
+  } catch (error) {
+    console.error("โหลดสินค้าไม่สำเร็จ", error);
+  }
 
   return (
-    <main className="min-h-screen bg-white">
-      <section className="max-w-6xl mx-auto px-6 py-16">
-        <h1 className="text-4xl font-bold">Bun Shop</h1>
-        <p className="text-gray-600 mt-2">ขนมนุ่ม หอมอร่อย — สั่งได้เลย 👇</p>
+    <main className="min-h-screen">
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-[#ffe0c7] via-[#ffe9d6] to-[#ffe0ec]" />
+        <div className="absolute -top-20 -right-10 h-72 w-72 rounded-full bg-[#fbd8a4]/60 blur-3xl" />
+        <div className="absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-[#f5a3c2]/40 blur-3xl" />
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mt-10">
-          {products.map((p) => (
-            <div key={p._id} className="border rounded-xl p-4">
-              <div className="aspect-square bg-gray-100 rounded-lg overflow-hidden">
-                {p.images?.[0] ? (
-                  <img
-                    src={p.images[0]}
-                    alt={p.title}
-                    className="w-full h-full object-cover"
-                  />
-                ) : null}
+        <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-20 grid gap-12 lg:grid-cols-2 items-center">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-sm font-medium text-[var(--color-rose-dark)] shadow">
+              70% OFF เมนูเช้า • ส่งฟรีทั่วเมือง
+            </span>
+            <h1 className="text-4xl sm:text-5xl font-extrabold leading-tight text-[var(--color-rose-dark)]">
+              ความสุขจากเตาอบ สู่โต๊ะอาหารของคุณ
+            </h1>
+            <p className="text-base sm:text-lg text-[var(--color-choco)]/80 max-w-xl">
+              ขนมปังหอมกรุ่น ครัวซองต์กรอบนอกนุ่มใน และเค้กสุดละมุน พร้อมเสิร์ฟทุกเช้าเพื่อเติมเต็มช่วงเวลาพิเศษให้ครอบครัวของคุณ
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <a
+                href="#menu"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
+              >
+                เลือกขนมเลย
+              </a>
+              <a
+                href="/checkout"
+                className="inline-flex items-center justify-center rounded-full border border-white/60 bg-white/70 px-6 py-3 text-sm font-semibold text-[var(--color-rose-dark)] shadow hover:bg-white"
+              >
+                สั่งด่วนภายในวันเดียว
+              </a>
+            </div>
+
+            <dl className="grid grid-cols-2 sm:grid-cols-3 gap-4 pt-4">
+              {["อบสดใหม่", "วัตถุดิบพรีเมียม", "ส่งไวในเมือง"].map((item) => (
+                <div key={item} className="rounded-2xl bg-white/70 px-4 py-3 text-sm font-medium text-[var(--color-choco)] shadow">
+                  {item}
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="relative flex justify-center">
+            <div className="relative h-[320px] w-[320px] sm:h-[360px] sm:w-[360px] rounded-[48%] bg-gradient-to-br from-white/80 via-white to-[#ffe9f2] shadow-2xl shadow-[#f0658322] flex items-center justify-center">
+              <div className="absolute -top-8 right-8 h-16 w-16 rounded-full bg-[#fcd9b6] shadow-lg shadow-[#fcd9b6]/50" />
+              <div className="absolute -bottom-6 left-10 h-20 w-20 rounded-full bg-[#f8acc5] shadow-lg shadow-[#f8acc5]/50" />
+              <div className="absolute top-10 left-6 h-12 w-12 rounded-full border-4 border-dashed border-white/70" />
+              <div className="text-center px-10">
+                <p className="text-lg font-semibold text-[var(--color-rose-dark)]">เมนูใหม่!</p>
+                <p className="mt-1 text-2xl font-black text-[var(--color-choco)]">Strawberry Brioche</p>
+                <p className="mt-4 text-sm text-[var(--color-choco)]/70">
+                  เนยสดคุณภาพสูง ผสานสตรอว์เบอร์รี่ออร์แกนิก เพิ่มความหวานอมเปรี้ยวอย่างลงตัว
+                </p>
               </div>
-              <h3 className="font-medium mt-4">{p.title}</h3>
-              <p className="text-gray-500 text-sm">{p.description}</p>
-              <div className="flex items-center justify-between mt-3">
-                <span className="font-semibold">฿{p.price}</span>
-                <AddToCartButton product={p} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="menu" className="max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--color-rose)]">Our Menu</p>
+            <h2 className="mt-2 text-3xl font-bold text-[var(--color-choco)]">ขนมอบที่ทุกคนหลงรัก</h2>
+            <p className="mt-2 text-[var(--color-choco)]/70 max-w-2xl">
+              คัดสรรวัตถุดิบธรรมชาติจากฟาร์มท้องถิ่น ผสมผสานความพิถีพิถันในการอบจนได้ขนมสดใหม่ หวานกำลังดี พร้อมส่งถึงคุณทุกเช้า
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <span className="inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-[var(--color-choco)] shadow">
+              🍓 พายผลไม้ตามฤดูกาล
+            </span>
+            <span className="inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-[var(--color-choco)] shadow">
+              ☕ เซตอาหารเช้า
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {products.length === 0 ? (
+            <div className="col-span-full rounded-3xl bg-white/90 p-10 text-center text-[var(--color-choco)]/70 shadow-lg shadow-[#f0658320]">
+              เมนูใหม่กำลังอบอยู่ รอสักครู่นะคะ 🍞
+            </div>
+          ) : (
+            products.map((p) => (
+              <div
+                key={p._id}
+                className="group relative flex h-full flex-col rounded-3xl bg-white/90 shadow-lg shadow-[#f0658320] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+              >
+                <div className="relative overflow-hidden rounded-t-3xl">
+                  <div className="aspect-square w-full bg-gradient-to-br from-[#ffe5d0] via-[#fff] to-[#ffe6f5] flex items-center justify-center">
+                    {p.images?.[0] ? (
+                      <img
+                        src={p.images[0]}
+                        alt={p.title}
+                        className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <span className="text-4xl">🍩</span>
+                    )}
+                  </div>
+                  <div className="absolute top-4 left-4 rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[var(--color-rose-dark)] shadow">
+                    เมนูแนะนำ
+                  </div>
+                </div>
+                <div className="flex flex-1 flex-col gap-3 p-6">
+                  <div>
+                    <h3 className="text-xl font-semibold text-[var(--color-choco)]">{p.title}</h3>
+                    <p className="mt-1 text-sm text-[var(--color-choco)]/70 line-clamp-3">{p.description}</p>
+                  </div>
+                  <div className="mt-auto flex items-center justify-between pt-2">
+                    <span className="text-lg font-bold text-[var(--color-rose-dark)]">฿{p.price}</span>
+                    <AddToCartButton product={p} />
+                  </div>
+                </div>
               </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="bg-white/70">
+        <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-16 grid gap-10 md:grid-cols-3">
+          {["Chef มืออาชีพ", "ส่งเร็วใน 2 ชม.", "มีเมนูสุขภาพ"].map((title, idx) => (
+            <div key={title} className="rounded-3xl bg-white p-8 shadow-md shadow-[#f0658315]">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[#f06583] to-[#f6c34a] text-white text-xl shadow">
+                {idx === 0 ? "👩‍🍳" : idx === 1 ? "🚚" : "💚"}
+              </div>
+              <h3 className="mt-6 text-xl font-semibold text-[var(--color-choco)]">{title}</h3>
+              <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+                {idx === 0
+                  ? "ทีมเชฟมากประสบการณ์ที่อบขนมทุกชิ้นอย่างพิถีพิถัน เพื่อรสชาติและคุณภาพที่ดีที่สุด"
+                  : idx === 1
+                  ? "บริการจัดส่งด่วนภายใน 2 ชั่วโมงในเขตเมือง เพื่อให้คุณได้รับขนมในสภาพสมบูรณ์"
+                  : "ตัวเลือกเมนูไร้น้ำตาลและวัตถุดิบออร์แกนิกสำหรับคนรักสุขภาพ"}
+              </p>
             </div>
           ))}
         </div>

--- a/app/(site)/register/page.js
+++ b/app/(site)/register/page.js
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import Link from "next/link";
 
 export default function RegisterPage() {
   const [loading, setLoading] = useState(false);
@@ -7,7 +8,8 @@ export default function RegisterPage() {
 
   async function onSubmit(e) {
     e.preventDefault();
-    setMsg(""); setLoading(true);
+    setMsg("");
+    setLoading(true);
     const form = new FormData(e.currentTarget);
     const res = await fetch("/api/auth/register", {
       method: "POST",
@@ -25,17 +27,73 @@ export default function RegisterPage() {
   }
 
   return (
-    <main className="max-w-md mx-auto px-6 py-10">
-      <h1 className="text-2xl font-bold mb-6">Register</h1>
-      <form onSubmit={onSubmit} className="space-y-4">
-        <input name="name" placeholder="ชื่อ" className="w-full border rounded px-3 py-2" required />
-        <input name="email" type="email" placeholder="อีเมล" className="w-full border rounded px-3 py-2" required />
-        <input name="password" type="password" placeholder="รหัสผ่าน (6+)" className="w-full border rounded px-3 py-2" required />
-        <button disabled={loading} className="w-full bg-black text-white rounded py-2">
-          {loading ? "กำลังสมัคร..." : "สมัครสมาชิก"}
-        </button>
-      </form>
-      {msg && <p className="text-sm text-gray-700 mt-4">{String(msg)}</p>}
+    <main className="relative min-h-[70vh] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe1d0] via-[#fff7f0] to-[#ffe1f5]" />
+      <div className="absolute -top-24 left-16 h-64 w-64 rounded-full bg-[#f06583]/20 blur-3xl" />
+      <div className="absolute -bottom-28 right-12 h-72 w-72 rounded-full bg-[#f6c34a]/25 blur-3xl" />
+
+      <div className="relative flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl bg-white/95 p-8 shadow-2xl shadow-[#f0658320]">
+          <div className="text-center">
+            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">สร้างบัญชีใหม่</h1>
+            <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+              สมัครสมาชิกเพื่อรับข่าวสาร โปรโมชั่น และสะสมคะแนนสำหรับลูกค้าประจำ
+            </p>
+          </div>
+
+          <form onSubmit={onSubmit} className="mt-8 space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium">ชื่อ-นามสกุล</label>
+              <input
+                name="name"
+                placeholder="ชื่อเต็ม"
+                className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">อีเมล</label>
+              <input
+                name="email"
+                type="email"
+                placeholder="name@example.com"
+                className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">รหัสผ่าน (6 ตัวอักษรขึ้นไป)</label>
+              <input
+                name="password"
+                type="password"
+                placeholder="รหัสผ่าน"
+                minLength={6}
+                className="w-full rounded-2xl border border-[#f7b267]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f06583]/30"
+                required
+              />
+            </div>
+            <button
+              disabled={loading}
+              className="w-full rounded-full bg-gradient-to-r from-[#f06583] to-[#f6c34a] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {loading ? "กำลังสมัคร..." : "สมัครสมาชิก"}
+            </button>
+          </form>
+
+          {msg && (
+            <p className={`mt-4 text-sm ${msg.includes("เสร็จ") ? "text-emerald-600" : "text-rose-600"}`}>
+              {String(msg)}
+            </p>
+          )}
+
+          <p className="mt-6 text-center text-sm text-[var(--color-choco)]/70">
+            มีบัญชีอยู่แล้ว?
+            <Link href="/login" className="ml-2 font-semibold text-[var(--color-rose)] hover:text-[var(--color-rose-dark)]">
+              เข้าสู่ระบบ
+            </Link>
+          </p>
+        </div>
+      </div>
     </main>
   );
 }

--- a/app/admin/coupons/page.jsx
+++ b/app/admin/coupons/page.jsx
@@ -1,43 +1,66 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import { useEffect, useMemo, useState } from "react";
+
+const emptyCoupon = {
+  code: "",
+  type: "percent",
+  value: 10,
+  minSubtotal: 0,
+  expiresAt: "",
+  active: true,
+};
 
 export default function AdminCouponsPage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
   const [editing, setEditing] = useState(null);
-  const [form, setForm] = useState({ code:"", type:"percent", value:10, minSubtotal:0, expiresAt:"", active:true });
+  const [form, setForm] = useState(emptyCoupon);
+  const [search, setSearch] = useState("");
+  const [saving, setSaving] = useState(false);
 
   async function load() {
-    setLoading(true); setErr("");
+    setLoading(true);
+    setErr("");
     try {
       const res = await fetch("/api/coupons", { cache: "no-store" });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || "Load failed");
       setItems(data);
-    } catch(e){ setErr(String(e.message || e)); }
-    finally { setLoading(false); }
+    } catch (e) {
+      setErr(String(e.message || e));
+    } finally {
+      setLoading(false);
+    }
   }
-  useEffect(() => { load(); }, []);
+
+  useEffect(() => {
+    load();
+  }, []);
 
   function startCreate() {
     setEditing({});
-    setForm({ code:"", type:"percent", value:10, minSubtotal:0, expiresAt:"", active:true });
+    setForm(emptyCoupon);
   }
-  function startEdit(c) {
-    setEditing(c);
+
+  function startEdit(coupon) {
+    setEditing(coupon);
     setForm({
-      code: c.code || "",
-      type: c.type || "percent",
-      value: Number(c.value || 0),
-      minSubtotal: Number(c.minSubtotal || 0),
-      expiresAt: c.expiresAt ? new Date(c.expiresAt).toISOString().slice(0,16) : "",
-      active: !!c.active,
+      code: coupon.code || "",
+      type: coupon.type || "percent",
+      value: Number(coupon.value || 0),
+      minSubtotal: Number(coupon.minSubtotal || 0),
+      expiresAt: coupon.expiresAt ? new Date(coupon.expiresAt).toISOString().slice(0, 16) : "",
+      active: !!coupon.active,
     });
   }
 
   async function onSubmit(e) {
     e.preventDefault();
+    if (saving) return;
+    setSaving(true);
+
     const payload = {
       code: form.code,
       type: form.type,
@@ -46,146 +69,265 @@ export default function AdminCouponsPage() {
       expiresAt: form.expiresAt || "",
       active: Boolean(form.active),
     };
+
     const url = editing?._id ? `/api/coupons/${editing._id}` : "/api/coupons";
     const method = editing?._id ? "PATCH" : "POST";
-    const res = await fetch(url, { method, headers:{ "Content-Type":"application/json" }, body: JSON.stringify(payload) });
-    const data = await res.json();
-    if (!res.ok) { alert(data?.error || "Save failed"); return; }
-    setEditing(null); await load();
-  }
-
-  async function toggleActive(c) {
-    const res = await fetch(`/api/coupons/${c._id}`, {
-      method: "PATCH", headers: { "Content-Type":"application/json" },
-      body: JSON.stringify({ active: !c.active }),
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
     const data = await res.json();
-    if (!res.ok) { alert(data?.error || "Update failed"); return; }
-    setItems(prev => prev.map(x => x._id === c._id ? { ...x, active: !c.active } : x));
-  }
-
-  async function onDelete(c) {
-    if (!confirm(`ลบคูปอง "${c.code}" ?`)) return;
-    const res = await fetch(`/api/coupons/${c._id}`, { method: "DELETE" });
-    const data = await res.json();
-    if (!res.ok) { alert(data?.error || "Delete failed"); return; }
+    setSaving(false);
+    if (!res.ok) {
+      alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ");
+      return;
+    }
+    setEditing(null);
     await load();
   }
 
+  async function toggleActive(coupon) {
+    const res = await fetch(`/api/coupons/${coupon._id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ active: !coupon.active }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data?.error || "Update failed");
+      return;
+    }
+    setItems((prev) => prev.map((c) => (c._id === coupon._id ? { ...c, active: !coupon.active } : c)));
+  }
+
+  async function onDelete(coupon) {
+    if (!confirm(`ลบคูปอง "${coupon.code}" ?`)) return;
+    const res = await fetch(`/api/coupons/${coupon._id}`, { method: "DELETE" });
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data?.error || "Delete failed");
+      return;
+    }
+    await load();
+  }
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return items;
+    return items.filter((coupon) => `${coupon.code} ${coupon.type}`.toLowerCase().includes(term));
+  }, [items, search]);
+
+  const activeCount = filtered.filter((coupon) => coupon.active).length;
+  const percentCount = filtered.filter((coupon) => coupon.type === "percent").length;
+  const amountCount = filtered.filter((coupon) => coupon.type === "amount").length;
+
   return (
-    <main className="max-w-5xl mx-auto px-6 py-10">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Coupons</h1>
-        <button className="px-3 py-2 rounded bg-black text-white" onClick={startCreate}>+ New Coupon</button>
-      </div>
-
-      {loading && <div className="mt-6">กำลังโหลด...</div>}
-      {err && <div className="mt-6 text-red-600">{err}</div>}
-
-      {!loading && !err && (
-        <div className="mt-6 overflow-x-auto">
-          <table className="min-w-full border rounded-lg overflow-hidden">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left p-3 border-b">Code</th>
-                <th className="text-left p-3 border-b">Type</th>
-                <th className="text-left p-3 border-b">Value</th>
-                <th className="text-left p-3 border-b">Min Subtotal</th>
-                <th className="text-left p-3 border-b">Expires</th>
-                <th className="text-left p-3 border-b">Active</th>
-                <th className="text-right p-3 border-b">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map(c => (
-                <tr key={c._id}>
-                  <td className="p-3 border-b font-semibold">{c.code}</td>
-                  <td className="p-3 border-b">{c.type}</td>
-                  <td className="p-3 border-b">{c.type === "percent" ? `${c.value}%` : `฿${c.value}`}</td>
-                  <td className="p-3 border-b">฿{c.minSubtotal}</td>
-                  <td className="p-3 border-b">{c.expiresAt ? new Date(c.expiresAt).toLocaleString() : "-"}</td>
-                  <td className="p-3 border-b">
-                    <button
-                      onClick={() => toggleActive(c)}
-                      className={`relative inline-flex items-center h-7 w-20 rounded-full transition-colors duration-300 ${c.active ? "bg-green-500" : "bg-gray-400"}`}
-                    >
-                      <span className={`absolute left-1 h-5 w-5 rounded-full bg-white shadow transform transition-transform duration-300 ${c.active ? "translate-x-12" : "translate-x-0"}`} />
-                      <span className="w-full text-center text-xs font-medium text-white select-none">
-                        {c.active ? "active" : "hidden"}
-                      </span>
-                    </button>
-                  </td>
-                  <td className="p-3 border-b text-right">
-                    <button className="mr-2 underline" onClick={() => startEdit(c)}>edit</button>
-                    <button className="text-red-600 underline" onClick={() => onDelete(c)}>delete</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <main className="space-y-10">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f0658314] backdrop-blur">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">คูปองและโปรโมชัน</h2>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              สร้างข้อเสนอพิเศษเพื่อดึงดูดลูกค้า และกำหนดเงื่อนไขให้ตรงกับกลยุทธ์การขาย
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="ค้นหาคูปอง"
+              className="w-52 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+            />
+            <button
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)]"
+              onClick={startCreate}
+            >
+              🎉 สร้างคูปองใหม่
+            </button>
+          </div>
         </div>
-      )}
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <CouponStat label="คูปองทั้งหมด" value={filtered.length} />
+          <CouponStat label="เปิดใช้งาน" value={activeCount} tone="from-[#7cd1b8]/30" />
+          <CouponStat label="ส่วนลด %" value={percentCount} tone="from-[#f6c34a]/30" />
+          <CouponStat label="ส่วนลดเป็นจำนวน" value={amountCount} tone="from-[#f78da7]/30" />
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f0658318]">
+        <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการคูปอง</h3>
+            <p className="text-xs text-[var(--color-choco)]/60">เปิด/ปิดการใช้งานและแก้ไขเงื่อนไขได้ทุกเมื่อ</p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-[var(--color-choco)]/50">
+            {filtered.length} รายการ
+          </span>
+        </header>
+
+        {loading && <p className="px-6 py-6 text-sm text-[var(--color-choco)]/70">กำลังโหลดข้อมูล...</p>}
+        {err && !loading && <p className="px-6 py-6 text-sm text-rose-600">{err}</p>}
+
+        {!loading && !err && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-y-2 px-4 py-4 text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-[var(--color-choco)]/50">
+                  <th className="px-4 py-2">โค้ด</th>
+                  <th className="px-4 py-2">ประเภท</th>
+                  <th className="px-4 py-2">มูลค่า</th>
+                  <th className="px-4 py-2">ขั้นต่ำ</th>
+                  <th className="px-4 py-2">หมดอายุ</th>
+                  <th className="px-4 py-2">สถานะ</th>
+                  <th className="px-4 py-2 text-right">จัดการ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((coupon) => (
+                  <tr key={coupon._id} className="rounded-3xl bg-white/80 shadow shadow-[#f0658312]">
+                    <td className="px-4 py-4 font-semibold text-[var(--color-choco)]">{coupon.code}</td>
+                    <td className="px-4 py-4 text-[var(--color-choco)]/70">{coupon.type}</td>
+                    <td className="px-4 py-4 text-[var(--color-choco)]">
+                      {coupon.type === "percent" ? `${coupon.value}%` : formatCurrency(coupon.value)}
+                    </td>
+                    <td className="px-4 py-4 text-[var(--color-choco)]">{formatCurrency(coupon.minSubtotal)}</td>
+                    <td className="px-4 py-4 text-xs text-[var(--color-choco)]/60">
+                      {coupon.expiresAt ? new Date(coupon.expiresAt).toLocaleString("th-TH") : "ไม่มีกำหนด"}
+                    </td>
+                    <td className="px-4 py-4">
+                      <button
+                        onClick={() => toggleActive(coupon)}
+                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition ${
+                          coupon.active
+                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
+                            : "bg-gray-200 text-gray-500"
+                        }`}
+                      >
+                        <span className="text-base">{coupon.active ? "💡" : "🌙"}</span>
+                        {coupon.active ? "ใช้งานอยู่" : "ปิดการใช้งาน"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-4 text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          className="rounded-full border border-[var(--color-rose)]/40 px-4 py-1 text-xs font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-[var(--color-rose)]/10"
+                          onClick={() => startEdit(coupon)}
+                        >
+                          แก้ไข
+                        </button>
+                        <button
+                          className="rounded-full border border-rose-200 px-4 py-1 text-xs font-semibold text-rose-500 transition hover:border-rose-400 hover:bg-rose-100"
+                          onClick={() => onDelete(coupon)}
+                        >
+                          ลบ
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
 
       {editing !== null && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl w-full max-w-xl p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">{editing?._id ? "Edit coupon" : "New coupon"}</h2>
-              <button className="text-sm underline" onClick={()=> setEditing(null)}>close</button>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
+          <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white/95 shadow-2xl shadow-[#f0658330]">
+            <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
+              <div>
+                <h3 className="text-lg font-semibold text-[var(--color-choco)]">
+                  {editing?._id ? "แก้ไขคูปอง" : "สร้างคูปองใหม่"}
+                </h3>
+                <p className="text-xs text-[var(--color-choco)]/60">
+                  เติมรายละเอียดเพื่อกำหนดสิทธิ์ให้ลูกค้าตามกลยุทธ์ของคุณ
+                </p>
+              </div>
+              <button
+                className="rounded-full border border-[var(--color-choco)]/10 bg-white px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/30 hover:text-[var(--color-choco)]"
+                onClick={() => setEditing(null)}
+              >
+                ปิด
+              </button>
             </div>
 
-            <form onSubmit={onSubmit} className="mt-4 grid grid-cols-1 gap-4">
-              <div>
-                <label className="text-sm block mb-1">Code</label>
-                <input className="w-full border rounded px-3 py-2"
+            <form onSubmit={onSubmit} className="space-y-4 px-6 py-6">
+              <Field label="รหัสคูปอง" required>
+                <input
+                  className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                   value={form.code}
-                  onChange={(e)=> setForm(f => ({...f, code:e.target.value.toUpperCase()}))}
+                  onChange={(e) => setForm((f) => ({ ...f, code: e.target.value.toUpperCase() }))}
                   required
                 />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="text-sm block mb-1">Type</label>
-                  <select className="w-full border rounded px-3 py-2"
+              </Field>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field label="ประเภทส่วนลด">
+                  <select
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.type}
-                    onChange={(e)=> setForm(f => ({...f, type:e.target.value}))}
+                    onChange={(e) => setForm((f) => ({ ...f, type: e.target.value }))}
                   >
-                    <option value="percent">percent (%)</option>
-                    <option value="amount">amount (THB)</option>
+                    <option value="percent">เปอร์เซ็นต์ (%)</option>
+                    <option value="amount">จำนวนเงิน (บาท)</option>
                   </select>
-                </div>
-                <div>
-                  <label className="text-sm block mb-1">Value</label>
-                  <input type="number" className="w-full border rounded px-3 py-2"
+                </Field>
+                <Field label="มูลค่าส่วนลด">
+                  <input
+                    type="number"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.value}
-                    onChange={(e)=> setForm(f => ({...f, value:Number(e.target.value || 0)}))}
+                    onChange={(e) => setForm((f) => ({ ...f, value: Number(e.target.value || 0) }))}
                   />
-                </div>
+                </Field>
               </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="text-sm block mb-1">Min Subtotal (THB)</label>
-                  <input type="number" className="w-full border rounded px-3 py-2"
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field label="ยอดสั่งซื้อขั้นต่ำ (บาท)">
+                  <input
+                    type="number"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.minSubtotal}
-                    onChange={(e)=> setForm(f => ({...f, minSubtotal:Number(e.target.value || 0)}))}
+                    onChange={(e) => setForm((f) => ({ ...f, minSubtotal: Number(e.target.value || 0) }))}
                   />
-                </div>
-                <div>
-                  <label className="text-sm block mb-1">Expires at</label>
-                  <input type="datetime-local" className="w-full border rounded px-3 py-2"
+                </Field>
+                <Field label="วันหมดอายุ">
+                  <input
+                    type="datetime-local"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.expiresAt}
-                    onChange={(e)=> setForm(f => ({...f, expiresAt:e.target.value}))}
+                    onChange={(e) => setForm((f) => ({ ...f, expiresAt: e.target.value }))}
                   />
-                </div>
+                </Field>
               </div>
-              <div className="flex items-center gap-2">
-                <input id="active" type="checkbox" checked={form.active}
-                  onChange={(e)=> setForm(f => ({...f, active:e.target.checked}))}/>
-                <label htmlFor="active" className="text-sm">Active</label>
-              </div>
-              <div className="pt-2 flex items-center gap-3">
-                <button className="px-4 py-2 rounded bg-black text-white">{editing?._id ? "บันทึก" : "สร้างคูปอง"}</button>
-                <button type="button" className="px-4 py-2 rounded border" onClick={()=> setEditing(null)}>ยกเลิก</button>
+
+              <label className="flex items-center gap-3 text-sm font-medium text-[var(--color-choco)]/80">
+                <input
+                  type="checkbox"
+                  checked={form.active}
+                  onChange={(e) => setForm((f) => ({ ...f, active: e.target.checked }))}
+                  className="h-4 w-4 rounded border-[var(--color-rose)]/40 text-[var(--color-rose)] focus:ring-[var(--color-rose)]"
+                />
+                เปิดใช้งานคูปองทันที
+              </label>
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  className="rounded-full border border-[var(--color-choco)]/20 px-5 py-2 text-sm font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/40 hover:text-[var(--color-choco)]"
+                  onClick={() => setEditing(null)}
+                >
+                  ยกเลิก
+                </button>
+                <button
+                  className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={saving}
+                >
+                  {saving ? "กำลังบันทึก..." : editing?._id ? "บันทึกการแก้ไข" : "สร้างคูปอง"}
+                </button>
               </div>
             </form>
           </div>
@@ -193,4 +335,36 @@ export default function AdminCouponsPage() {
       )}
     </main>
   );
+}
+
+function Field({ label, required, children }) {
+  return (
+    <label className="block text-sm font-medium text-[var(--color-choco)]/80">
+      <span className="mb-2 block">
+        {label}
+        {required ? <span className="ml-1 text-rose-500">*</span> : null}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function CouponStat({ label, value, tone }) {
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/70 bg-white/80 p-4 text-sm font-semibold text-[var(--color-choco)] shadow-inner">
+      {tone ? <div className={`pointer-events-none absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br ${tone}`} /> : null}
+      <div className="relative">
+        <p className="text-xs uppercase tracking-wide text-[var(--color-choco)]/50">{label}</p>
+        <p className="mt-2 text-xl text-[var(--color-rose-dark)]">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function formatCurrency(value) {
+  const amount = Number(value || 0);
+  return `฿${amount.toLocaleString("th-TH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }

--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -1,16 +1,42 @@
+import Link from "next/link";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export const metadata = { title: "Admin | Sweet Cravings" };
 
 export default function AdminLayout({ children }) {
   return (
-    <div className="min-h-screen flex bg-gradient-to-br from-[#fff2e5] via-[#fff7f0] to-[#ffe6f2] text-[var(--color-choco)]">
+    <div className="relative min-h-screen bg-[radial-gradient(circle_at_20%_20%,#ffe6f2,transparent_55%),radial-gradient(circle_at_80%_0%,#fff1dd,transparent_45%),radial-gradient(circle_at_100%_80%,#ffe9fb,transparent_35%)] text-[var(--color-choco)] lg:flex">
       <AdminSidebar />
-      <main className="flex-1 backdrop-blur-sm">
-        <div className="h-16 border-b border-white/60 bg-white/70 px-8 flex items-center text-lg font-semibold text-[var(--color-rose-dark)] shadow-sm">
-          แผงควบคุมร้านค้า
+
+      <main className="flex-1 lg:ml-0">
+        <div className="sticky top-0 z-30 border-b border-white/60 bg-white/70 backdrop-blur-md">
+          <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between lg:px-10">
+            <div>
+              <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-choco)]/60">
+                Sweet Cravings Admin
+              </p>
+              <h1 className="mt-1 text-2xl font-semibold text-[var(--color-rose-dark)]">
+                แผงควบคุมการจัดการร้าน
+              </h1>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Link
+                href="/"
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-white"
+              >
+                🏬 กลับหน้าร้าน
+              </Link>
+              <Link
+                href="/orders"
+                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)]"
+              >
+                🛒 ดูร้านแบบลูกค้า
+              </Link>
+            </div>
+          </div>
         </div>
-        <div className="p-8">{children}</div>
+
+        <div className="px-5 pb-20 pt-8 lg:px-10">{children}</div>
       </main>
     </div>
   );

--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -1,14 +1,16 @@
 import AdminSidebar from "@/components/admin/AdminSidebar";
 
-export const metadata = { title: "Admin | Bun Shop" };
+export const metadata = { title: "Admin | Sweet Cravings" };
 
 export default function AdminLayout({ children }) {
   return (
-    <div className="min-h-screen flex">
+    <div className="min-h-screen flex bg-gradient-to-br from-[#fff2e5] via-[#fff7f0] to-[#ffe6f2] text-[var(--color-choco)]">
       <AdminSidebar />
-      <main className="flex-1">
-        <div className="h-14 border-b flex items-center px-6">Admin Panel</div>
-        <div className="p-6">{children}</div>
+      <main className="flex-1 backdrop-blur-sm">
+        <div className="h-16 border-b border-white/60 bg-white/70 px-8 flex items-center text-lg font-semibold text-[var(--color-rose-dark)] shadow-sm">
+          แผงควบคุมร้านค้า
+        </div>
+        <div className="p-8">{children}</div>
       </main>
     </div>
   );

--- a/app/admin/orders/page.jsx
+++ b/app/admin/orders/page.jsx
@@ -1,10 +1,33 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import { useEffect, useMemo, useState } from "react";
+
+const statusOptions = ["all", "new", "preparing", "shipped", "done", "cancelled"];
+
+const statusLabels = {
+  all: "ทั้งหมด",
+  new: "รอจัดเตรียม",
+  preparing: "กำลังจัดเตรียม",
+  shipped: "ส่งออกแล้ว",
+  done: "สำเร็จ",
+  cancelled: "ยกเลิก",
+};
+
+const statusStyles = {
+  new: "bg-[#fff1dd] text-[var(--color-choco)]",
+  preparing: "bg-[#f6c34a]/30 text-[var(--color-choco)]",
+  shipped: "bg-[#7cd1b8]/30 text-[#1f7a65]",
+  done: "bg-[#7cd1b8]/40 text-[#1f7a65]",
+  cancelled: "bg-rose-100 text-rose-500",
+};
 
 export default function AdminOrdersPage() {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
+  const [filter, setFilter] = useState("all");
+  const [selectedSlip, setSelectedSlip] = useState(null);
+  const [updating, setUpdating] = useState("");
 
   async function load() {
     setLoading(true);
@@ -20,17 +43,20 @@ export default function AdminOrdersPage() {
       setLoading(false);
     }
   }
+
   useEffect(() => {
     load();
   }, []);
 
   async function updateStatus(id, status) {
+    setUpdating(id + status);
     const res = await fetch(`/api/orders/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status }),
     });
     const data = await res.json();
+    setUpdating("");
     if (!res.ok) {
       alert(data?.error || "Update failed");
       return;
@@ -38,78 +64,292 @@ export default function AdminOrdersPage() {
     setOrders((prev) => prev.map((o) => (o._id === id ? { ...o, status } : o)));
   }
 
+  const filteredOrders = useMemo(() => {
+    if (filter === "all") return orders;
+    return orders.filter((o) => o.status === filter);
+  }, [orders, filter]);
+
+  const totalToday = useMemo(() => {
+    return filteredOrders.reduce((sum, order) => sum + Number(order.total || 0), 0);
+  }, [filteredOrders]);
+
   if (loading)
-    return <main className="max-w-6xl mx-auto px-6 py-10">กำลังโหลด...</main>;
+    return (
+      <main className="rounded-3xl border border-white/80 bg-white/80 px-6 py-10 text-[var(--color-choco)]/70 shadow-lg shadow-[#f0658314]">
+        กำลังโหลดคำสั่งซื้อ...
+      </main>
+    );
+
   if (err)
     return (
-      <main className="max-w-6xl mx-auto px-6 py-10 text-red-600">{err}</main>
+      <main className="rounded-3xl border border-rose-200 bg-rose-50/80 px-6 py-10 text-rose-600 shadow-lg">
+        {err}
+      </main>
     );
 
   return (
-    <main className="max-w-6xl mx-auto px-6 py-10">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Orders</h1>
-        <a href="/api/admin/export/orders" className="px-3 py-2 rounded border">
-          Export CSV
-        </a>
-      </div>
-      <table className="w-full border">
-        <thead className="bg-gray-50">
-          <tr>
-            <th className="p-2 border">Order</th>
-            <th className="p-2 border">Items</th>
-            <th className="p-2 border">Total</th>
-            <th className="p-2 border">Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map((o) => (
-            <tr key={o._id}>
-              <td className="p-2 border">
-                <div className="font-medium">#{o._id.slice(-8)}</div>
-                <div className="text-xs text-gray-500">
-                  {new Date(o.createdAt).toLocaleString()}
-                </div>
-              </td>
-              <td className="p-2 border">
-                {o.items.map((it, idx) => (
-                  <div
-                    key={`${o._id}-${it.productId || it.title}-${idx}`}
-                    className="flex justify-between"
-                  >
-                    <span>
-                      {it.title} × {it.qty}
-                    </span>
-                    <span>฿{it.price * it.qty}</span>
-                  </div>
+    <main className="space-y-10">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f0658314] backdrop-blur">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">คำสั่งซื้อทั้งหมด</h2>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              ติดตามสถานะการจ่ายเงิน จัดเตรียมสินค้า และการจัดส่งให้ครบถ้วนในที่เดียว
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-4 py-2 text-xs font-semibold text-[var(--color-choco)]/70 shadow-inner">
+              <span>กรองตามสถานะ</span>
+              <select
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="rounded-full border border-transparent bg-transparent text-[var(--color-rose)] focus:outline-none"
+              >
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {statusLabels[status]}
+                  </option>
                 ))}
-              </td>
-              <td className="p-2 border">฿{o.total}</td>
-              <td className="p-2 border">
-                <select
-                  value={o.status}
-                  onChange={(e) => updateStatus(o._id, e.target.value)}
-                  className="border rounded px-2 py-1"
-                >
-                  {["new", "preparing", "shipped", "done", "cancelled"].map(
-                    (s) => (
-                      <option key={s} value={s}>
-                        {s}
-                      </option>
-                    )
-                  )}
-                </select>
-                <button
-                  className="ml-2 text-red-600 underline"
-                  onClick={() => updateStatus(o._id, "cancelled")}
-                >
-                  cancel
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              </select>
+            </label>
+            <a
+              href="/api/admin/export/orders"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)]"
+            >
+              ⬇️ ส่งออก CSV
+            </a>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <OrderHighlight label="รายการที่แสดง" value={filteredOrders.length} />
+          <OrderHighlight label="ยอดรวม" value={formatCurrency(totalToday)} />
+          <OrderHighlight label="คำสั่งซื้อที่รอจัดการ" value={orders.filter((o) => o.status === "new").length} />
+          <OrderHighlight label="อัปเดตล่าสุด" value={new Date().toLocaleTimeString()} subtle />
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        {filteredOrders.length === 0 ? (
+          <div className="rounded-3xl border border-white/70 bg-white/70 px-6 py-16 text-center text-[var(--color-choco)]/60 shadow-inner">
+            ยังไม่มีคำสั่งซื้อในสถานะนี้
+          </div>
+        ) : (
+          filteredOrders.map((order) => (
+            <article
+              key={order._id}
+              className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-xl shadow-[#f0658314] backdrop-blur"
+            >
+              <header className="flex flex-col gap-3 border-b border-white/60 pb-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-[var(--color-choco)]/60">คำสั่งซื้อ #{order._id.slice(-6)}</p>
+                  <h3 className="text-xl font-semibold text-[var(--color-choco)]">
+                    {order.customer?.name || "ลูกค้าทั่วไป"}
+                  </h3>
+                  <p className="text-xs text-[var(--color-choco)]/50">
+                    {new Date(order.createdAt).toLocaleString("th-TH")}
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold ${statusStyles[order.status] || "bg-white"}`}>
+                    <span className="text-base">📦</span>
+                    {statusLabels[order.status] || order.status}
+                  </span>
+                  <label className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/40 bg-white/70 px-3 py-2 text-xs text-[var(--color-choco)]/70">
+                    <span className="font-semibold text-[var(--color-choco)]">อัปเดตสถานะ</span>
+                    <select
+                      value={order.status}
+                      onChange={(e) => updateStatus(order._id, e.target.value)}
+                      className="rounded-full border border-transparent bg-transparent text-[var(--color-rose)] focus:outline-none"
+                      disabled={updating === order._id + order.status}
+                    >
+                      {statusOptions
+                        .filter((option) => option !== "all")
+                        .map((option) => (
+                          <option key={option} value={option}>
+                            {statusLabels[option]}
+                          </option>
+                        ))}
+                    </select>
+                  </label>
+                </div>
+              </header>
+
+              <div className="mt-4 grid gap-6 lg:grid-cols-[2fr_1fr]">
+                <div className="space-y-4">
+                  <div className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow-inner">
+                    <h4 className="text-sm font-semibold uppercase tracking-wide text-[var(--color-choco)]/50">
+                      รายการสินค้า
+                    </h4>
+                    <ul className="mt-3 space-y-2 text-sm text-[var(--color-choco)]">
+                      {order.items.map((item, idx) => (
+                        <li key={`${order._id}-${idx}`} className="flex items-center justify-between gap-3">
+                          <span>
+                            {item.title} × {item.qty}
+                          </span>
+                          <span className="font-semibold">{formatCurrency(item.price * item.qty)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow-inner">
+                    <h4 className="text-sm font-semibold uppercase tracking-wide text-[var(--color-choco)]/50">
+                      ที่อยู่จัดส่ง
+                    </h4>
+                    <p className="mt-2 text-sm leading-relaxed text-[var(--color-choco)]/75">
+                      {order.shipping?.address1}
+                      {order.shipping?.address2 ? ` ${order.shipping.address2}` : ""}
+                      <br />
+                      {order.shipping?.district} {order.shipping?.province} {order.shipping?.postcode}
+                    </p>
+                    {order.shipping?.note ? (
+                      <p className="mt-2 rounded-2xl bg-[var(--color-rose)]/10 px-3 py-2 text-xs text-[var(--color-rose)]">
+                        บันทึกจากลูกค้า: {order.shipping.note}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="rounded-2xl border border-white/60 bg-white/70 p-4 text-sm text-[var(--color-choco)] shadow-inner">
+                    <h4 className="text-sm font-semibold uppercase tracking-wide text-[var(--color-choco)]/50">
+                      สรุปยอดชำระ
+                    </h4>
+                    <div className="mt-3 space-y-2">
+                      <SummaryRow label="ยอดสินค้า" value={formatCurrency(order.subtotal)} />
+                      <SummaryRow label="ส่วนลด" value={formatCurrency(-order.discount)} negative={order.discount > 0} />
+                      <SummaryRow label="ยอดชำระรวม" value={formatCurrency(order.total)} strong />
+                    </div>
+                    {order.coupon?.code ? (
+                      <p className="mt-3 rounded-full bg-[var(--color-rose)]/10 px-3 py-1 text-xs font-semibold text-[var(--color-rose)]">
+                        ใช้คูปอง {order.coupon.code}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 p-4 text-sm text-[var(--color-choco)] shadow-inner">
+                    <h4 className="text-sm font-semibold uppercase tracking-wide text-[var(--color-choco)]/50">
+                      การชำระเงิน
+                    </h4>
+                    <p className="mt-2 flex items-center justify-between gap-4">
+                      <span>
+                        วิธีชำระ: <strong>{formatPaymentMethod(order.payment?.method)}</strong>
+                      </span>
+                      <span className="rounded-full bg-white/70 px-3 py-1 text-xs font-semibold text-[var(--color-rose)]">
+                        {order.payment?.status === "paid" ? "ชำระแล้ว" : "รอตรวจสอบ"}
+                      </span>
+                    </p>
+                    {order.payment?.amountPaid ? (
+                      <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+                        ยอดที่ลูกค้าแจ้ง: {formatCurrency(order.payment.amountPaid)}
+                      </p>
+                    ) : null}
+                    {order.payment?.ref ? (
+                      <p className="mt-1 text-xs text-[var(--color-choco)]/60">เลขอ้างอิง: {order.payment.ref}</p>
+                    ) : null}
+                    {order.payment?.slip ? (
+                      <button
+                        className="mt-3 inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-xs font-semibold text-[var(--color-rose)] shadow hover:bg-white/90"
+                        onClick={() => setSelectedSlip({
+                          slip: order.payment.slip,
+                          filename: order.payment.slipFilename || `slip-${order._id}.jpg`,
+                        })}
+                      >
+                        🧾 ดูสลิปการโอน
+                      </button>
+                    ) : null}
+                    {order.payment?.confirmedAt ? (
+                      <p className="mt-3 text-xs text-[var(--color-choco)]/60">
+                        ยืนยันการชำระเมื่อ {new Date(order.payment.confirmedAt).toLocaleString("th-TH")}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+
+      {selectedSlip ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-10 backdrop-blur"
+          onClick={() => setSelectedSlip(null)}
+        >
+          <div
+            className="max-h-full w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white shadow-2xl shadow-[#f0658330]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-5 py-3 text-sm font-semibold text-[var(--color-choco)]">
+              สลิปการโอน
+              <button
+                className="rounded-full border border-[var(--color-choco)]/20 px-3 py-1 text-xs text-[var(--color-choco)]/70"
+                onClick={() => setSelectedSlip(null)}
+              >
+                ปิด
+              </button>
+            </div>
+            <div className="max-h-[70vh] overflow-auto bg-black/5">
+              <img src={selectedSlip.slip} alt="Payment slip" className="h-full w-full object-contain" />
+            </div>
+            <a
+              href={selectedSlip.slip}
+              download={selectedSlip.filename}
+              className="block bg-white px-5 py-3 text-center text-sm font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-rose)]/10"
+            >
+              ดาวน์โหลดสลิป
+            </a>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
+}
+
+function OrderHighlight({ label, value, subtle = false }) {
+  return (
+    <div
+      className={`rounded-3xl border border-white/70 px-4 py-4 text-sm font-semibold shadow-inner ${
+        subtle ? "bg-white/60 text-[var(--color-choco)]/60" : "bg-white/80 text-[var(--color-choco)]"
+      }`}
+    >
+      <p className="text-xs uppercase tracking-wide text-[var(--color-choco)]/50">{label}</p>
+      <p className="mt-2 text-xl text-[var(--color-rose-dark)]">{value}</p>
+    </div>
+  );
+}
+
+function SummaryRow({ label, value, strong = false, negative = false }) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-[var(--color-choco)]/60">{label}</span>
+      <span
+        className={`${strong ? "text-lg font-semibold text-[var(--color-rose-dark)]" : "font-medium text-[var(--color-choco)]"} ${
+          negative ? "text-rose-500" : ""
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function formatCurrency(value) {
+  const amount = Number(value || 0);
+  return `฿${amount.toLocaleString("th-TH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatPaymentMethod(method) {
+  switch (method) {
+    case "promptpay":
+      return "PromptPay QR";
+    case "bank":
+      return "โอนผ่านบัญชีธนาคาร";
+    default:
+      return "ไม่ระบุ";
+  }
 }

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -24,6 +24,27 @@ export default function AdminDashboardPage() {
     })();
   }, []);
 
+  const lowStock = data?.cards?.lowStock ?? 0;
+
+  const reminders = useMemo(() => {
+    const list = [];
+    if (lowStock > 0) {
+      list.push({
+        title: "เติมสต็อกสินค้ายอดนิยม",
+        detail: `มี ${lowStock} รายการที่กำลังจะหมด เลือกเติมสต็อกก่อนเวลาเปิดร้านพรุ่งนี้`,
+      });
+    }
+    list.push({
+      title: "ตรวจสอบสลิปเงินเข้า",
+      detail: "ยืนยันการชำระเงินจากหน้า 'คำสั่งซื้อ' เพื่อให้ลูกค้าได้รับการจัดส่งเร็วที่สุด",
+    });
+    list.push({
+      title: "วางแผนโปรโมชั่น",
+      detail: "สร้างคูปองส่วนลดใหม่เพื่อกระตุ้นยอดขายช่วงสุดสัปดาห์",
+    });
+    return list;
+  }, [lowStock]);
+
   if (err)
     return (
       <section className="rounded-3xl border border-rose-200/60 bg-rose-50/80 p-6 text-rose-700 shadow-sm">
@@ -38,25 +59,6 @@ export default function AdminDashboardPage() {
     );
 
   const { cards, topProducts } = data;
-
-  const reminders = useMemo(() => {
-    const list = [];
-    if (cards.lowStock > 0) {
-      list.push({
-        title: "เติมสต็อกสินค้ายอดนิยม",
-        detail: `มี ${cards.lowStock} รายการที่กำลังจะหมด เลือกเติมสต็อกก่อนเวลาเปิดร้านพรุ่งนี้`,
-      });
-    }
-    list.push({
-      title: "ตรวจสอบสลิปเงินเข้า",
-      detail: "ยืนยันการชำระเงินจากหน้า 'คำสั่งซื้อ' เพื่อให้ลูกค้าได้รับการจัดส่งเร็วที่สุด",
-    });
-    list.push({
-      title: "วางแผนโปรโมชั่น",
-      detail: "สร้างคูปองส่วนลดใหม่เพื่อกระตุ้นยอดขายช่วงสุดสัปดาห์",
-    });
-    return list;
-  }, [cards.lowStock]);
 
   return (
     <div className="space-y-12">

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -12,59 +12,78 @@ export default function AdminDashboardPage() {
         const d = await res.json();
         if (!res.ok) throw new Error(d?.error || "Load stats failed");
         setData(d);
-      } catch (e) { setErr(String(e.message || e)); }
+      } catch (e) {
+        setErr(String(e.message || e));
+      }
     })();
   }, []);
 
-  if (err) return <div className="p-6 text-red-600">{err}</div>;
-  if (!data) return <div className="p-6">กำลังโหลด...</div>;
+  if (err) return <div className="p-6 text-rose-600">{err}</div>;
+  if (!data) return <div className="p-6 text-[var(--color-choco)]/70">กำลังโหลด...</div>;
 
   const { cards, topProducts } = data;
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-2">Admin Dashboard</h1>
-      <p className="text-sm text-gray-600 mb-6">สวัสดีแอดมิน ✨</p>
-
-      <div className="grid md:grid-cols-3 gap-4">
-        <Card title="ยอดขายวันนี้" value={`฿${cards.todaySales}`} />
-        <Card title="ออเดอร์ใหม่" value={cards.newOrders} />
-        <Card title="สต็อกต่ำ" value={cards.lowStock} />
+    <div className="space-y-10">
+      <div>
+        <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ภาพรวมร้าน Sweet Cravings</h1>
+        <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+          ตรวจสอบยอดขาย ออเดอร์ และสินค้ายอดนิยมแบบเรียลไทม์ เพื่อวางแผนการผลิตได้อย่างแม่นยำ
+        </p>
       </div>
 
-      <div className="mt-8">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Top products</h2>
-          <a href="/api/admin/export/sales" className="px-3 py-1.5 rounded border">Export CSV</a>
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card title="ยอดขายวันนี้" value={`฿${cards.todaySales}`} accent="from-[#f6c34a] to-[#f78da7]" />
+        <Card title="ออเดอร์ใหม่" value={cards.newOrders} accent="from-[#f06583] to-[#f6c34a]" />
+        <Card title="สต็อกต่ำ" value={cards.lowStock} accent="from-[#7cd1b8] to-[#f6c34a]" />
+      </div>
+
+      <div className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[#f0658320]">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[var(--color-choco)]">สินค้า Top ของเดือน</h2>
+            <p className="text-sm text-[var(--color-choco)]/60">ข้อมูลนี้อัปเดตรายวัน พร้อม export เพื่อนำไปวิเคราะห์ต่อ</p>
+          </div>
+          <a
+            href="/api/admin/export/sales"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
+          >
+            ดาวน์โหลด CSV
+          </a>
         </div>
-        <table className="w-full mt-3 border">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="p-2 border">สินค้า</th>
-              <th className="p-2 border">จำนวน</th>
-              <th className="p-2 border">รายได้</th>
-            </tr>
-          </thead>
-          <tbody>
-            {topProducts.map((p) => (
-              <tr key={p._id}>
-                <td className="p-2 border">{p._id}</td>
-                <td className="p-2 border">{p.qty}</td>
-                <td className="p-2 border">฿{p.revenue}</td>
+        <div className="mt-6 overflow-hidden rounded-2xl border border-[#f7b267]/40">
+          <table className="w-full text-sm">
+            <thead className="bg-[#fff1dd] text-[var(--color-choco)]/80">
+              <tr>
+                <th className="p-3 text-left font-medium">สินค้า</th>
+                <th className="p-3 text-right font-medium">จำนวน</th>
+                <th className="p-3 text-right font-medium">รายได้</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {topProducts.map((p) => (
+                <tr key={p._id} className="odd:bg-white even:bg-[#fff7f0] text-[var(--color-choco)]/80">
+                  <td className="p-3">{p._id}</td>
+                  <td className="p-3 text-right">{p.qty}</td>
+                  <td className="p-3 text-right">฿{p.revenue}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );
 }
 
-function Card({ title, value }) {
+function Card({ title, value, accent }) {
   return (
-    <div className="border rounded-xl p-4">
-      <div className="text-sm text-gray-600">{title}</div>
-      <div className="text-2xl font-bold mt-2">{value}</div>
+    <div className="relative overflow-hidden rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f065831a]">
+      <div className={`absolute -top-12 -right-6 h-32 w-32 rounded-full bg-gradient-to-br ${accent} opacity-30`} />
+      <div className="relative">
+        <div className="text-sm font-medium text-[var(--color-choco)]/70">{title}</div>
+        <div className="mt-4 text-3xl font-semibold text-[var(--color-rose-dark)]">{value}</div>
+      </div>
     </div>
   );
 }

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -1,5 +1,11 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+const statusChips = [
+  { key: "todaySales", label: "ยอดขายวันนี้", prefix: "฿" },
+  { key: "newOrders", label: "ออเดอร์ใหม่", prefix: "" },
+  { key: "lowStock", label: "สินค้าใกล้หมด", prefix: "" },
+];
 
 export default function AdminDashboardPage() {
   const [data, setData] = useState(null);
@@ -18,71 +24,209 @@ export default function AdminDashboardPage() {
     })();
   }, []);
 
-  if (err) return <div className="p-6 text-rose-600">{err}</div>;
-  if (!data) return <div className="p-6 text-[var(--color-choco)]/70">กำลังโหลด...</div>;
+  if (err)
+    return (
+      <section className="rounded-3xl border border-rose-200/60 bg-rose-50/80 p-6 text-rose-700 shadow-sm">
+        {err}
+      </section>
+    );
+  if (!data)
+    return (
+      <section className="rounded-3xl border border-white/60 bg-white/70 p-6 text-[var(--color-choco)]/70 shadow-sm">
+        กำลังโหลดข้อมูลร้าน...
+      </section>
+    );
 
   const { cards, topProducts } = data;
 
+  const reminders = useMemo(() => {
+    const list = [];
+    if (cards.lowStock > 0) {
+      list.push({
+        title: "เติมสต็อกสินค้ายอดนิยม",
+        detail: `มี ${cards.lowStock} รายการที่กำลังจะหมด เลือกเติมสต็อกก่อนเวลาเปิดร้านพรุ่งนี้`,
+      });
+    }
+    list.push({
+      title: "ตรวจสอบสลิปเงินเข้า",
+      detail: "ยืนยันการชำระเงินจากหน้า 'คำสั่งซื้อ' เพื่อให้ลูกค้าได้รับการจัดส่งเร็วที่สุด",
+    });
+    list.push({
+      title: "วางแผนโปรโมชั่น",
+      detail: "สร้างคูปองส่วนลดใหม่เพื่อกระตุ้นยอดขายช่วงสุดสัปดาห์",
+    });
+    return list;
+  }, [cards.lowStock]);
+
   return (
-    <div className="space-y-10">
-      <div>
-        <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ภาพรวมร้าน Sweet Cravings</h1>
-        <p className="mt-2 text-sm text-[var(--color-choco)]/70">
-          ตรวจสอบยอดขาย ออเดอร์ และสินค้ายอดนิยมแบบเรียลไทม์ เพื่อวางแผนการผลิตได้อย่างแม่นยำ
-        </p>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-3">
-        <Card title="ยอดขายวันนี้" value={`฿${cards.todaySales}`} accent="from-[#f6c34a] to-[#f78da7]" />
-        <Card title="ออเดอร์ใหม่" value={cards.newOrders} accent="from-[#f06583] to-[#f6c34a]" />
-        <Card title="สต็อกต่ำ" value={cards.lowStock} accent="from-[#7cd1b8] to-[#f6c34a]" />
-      </div>
-
-      <div className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[#f0658320]">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-12">
+      <section className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-[#f0658320] backdrop-blur">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-[var(--color-choco)]">สินค้า Top ของเดือน</h2>
-            <p className="text-sm text-[var(--color-choco)]/60">ข้อมูลนี้อัปเดตรายวัน พร้อม export เพื่อนำไปวิเคราะห์ต่อ</p>
+            <h2 className="text-3xl font-semibold text-[var(--color-rose-dark)]">
+              ภาพรวมร้านวันนี้
+            </h2>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-[var(--color-choco)]/70">
+              ตรวจสอบยอดขาย ออเดอร์ และสต็อกสินค้าในมุมมองเดียว เพื่อวางแผนการผลิตและบริการลูกค้าได้อย่างมั่นใจ
+            </p>
           </div>
-          <a
-            href="/api/admin/export/sales"
-            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] hover:bg-[var(--color-rose-dark)]"
-          >
-            ดาวน์โหลด CSV
-          </a>
+          <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-choco)]/60">
+            {statusChips.map((chip) => (
+              <div
+                key={chip.key}
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 px-4 py-2"
+              >
+                <span className="text-[var(--color-rose)]">{chip.label}</span>
+                <span className="text-[var(--color-choco)]">
+                  {chip.prefix}
+                  {cards[chip.key]}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="mt-6 overflow-hidden rounded-2xl border border-[#f7b267]/40">
-          <table className="w-full text-sm">
-            <thead className="bg-[#fff1dd] text-[var(--color-choco)]/80">
-              <tr>
-                <th className="p-3 text-left font-medium">สินค้า</th>
-                <th className="p-3 text-right font-medium">จำนวน</th>
-                <th className="p-3 text-right font-medium">รายได้</th>
-              </tr>
-            </thead>
-            <tbody>
-              {topProducts.map((p) => (
-                <tr key={p._id} className="odd:bg-white even:bg-[#fff7f0] text-[var(--color-choco)]/80">
-                  <td className="p-3">{p._id}</td>
-                  <td className="p-3 text-right">{p.qty}</td>
-                  <td className="p-3 text-right">฿{p.revenue}</td>
-                </tr>
+
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          <StatCard
+            title="ยอดขายวันนี้"
+            value={`฿${cards.todaySales}`}
+            caption="เปรียบเทียบจากยอดรวมที่ยืนยันแล้ว"
+            accent="from-[#f6c34a]/80 via-[#f78da7]/40 to-transparent"
+          />
+          <StatCard
+            title="ออเดอร์ใหม่"
+            value={cards.newOrders}
+            caption="ตรวจสอบรายละเอียดก่อน 18:00 น. เพื่อจัดส่งทันวันถัดไป"
+            accent="from-[#f06583]/60 via-[#f6c34a]/40 to-transparent"
+          />
+          <StatCard
+            title="สินค้าใกล้หมด"
+            value={cards.lowStock}
+            caption="เติมสต็อกล่วงหน้าเพื่อไม่ให้ยอดขายสะดุด"
+            accent="from-[#7cd1b8]/60 via-[#f6c34a]/40 to-transparent"
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          <div className="rounded-3xl border border-[#f7b267]/40 bg-[#fff7f0]/80 p-6 shadow-lg shadow-[#f0658318]">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-[var(--color-choco)]">
+                  สินค้าที่ขายดีที่สุดประจำเดือน
+                </h3>
+                <p className="text-sm text-[var(--color-choco)]/60">
+                  ข้อมูลอัปเดตรายวัน พร้อมดาวน์โหลดไฟล์เพื่อวิเคราะห์ต่อ
+                </p>
+              </div>
+              <a
+                href="/api/admin/export/sales"
+                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)]"
+              >
+                ⬇️ ดาวน์โหลด CSV
+              </a>
+            </div>
+
+            <div className="mt-6 overflow-hidden rounded-2xl border border-white/60 bg-white/70">
+              <table className="w-full text-sm text-[var(--color-choco)]/80">
+                <thead className="bg-[#fff1dd] text-[var(--color-choco)]/80">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">สินค้า</th>
+                    <th className="px-4 py-3 text-right font-medium">จำนวนที่ขาย</th>
+                    <th className="px-4 py-3 text-right font-medium">รายได้ (฿)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topProducts.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="px-4 py-6 text-center text-sm text-[var(--color-choco)]/60">
+                        ยังไม่มีข้อมูลยอดขายสำหรับช่วงเวลานี้
+                      </td>
+                    </tr>
+                  ) : (
+                    topProducts.map((p, idx) => (
+                      <tr key={p._id} className={idx % 2 === 0 ? "bg-white" : "bg-[#fff7f0]"}>
+                        <td className="px-4 py-3 font-medium">{p._id}</td>
+                        <td className="px-4 py-3 text-right">{p.qty}</td>
+                        <td className="px-4 py-3 text-right">{p.revenue}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-[#f0658318]">
+            <h3 className="text-xl font-semibold text-[var(--color-choco)]">รายการงานด่วนวันนี้</h3>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/60">
+              จัดลำดับความสำคัญเพื่อให้ทีมในครัวและหน้าร้านทำงานสอดคล้องกัน
+            </p>
+            <ul className="mt-5 space-y-4">
+              {reminders.map((item, index) => (
+                <li key={`${item.title}-${index}`} className="rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-rose)]/5 p-4">
+                  <p className="font-semibold text-[var(--color-choco)]">{item.title}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-[var(--color-choco)]/65">{item.detail}</p>
+                </li>
               ))}
-            </tbody>
-          </table>
+            </ul>
+          </div>
         </div>
-      </div>
+
+        <div className="space-y-6">
+          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f0658318]">
+            <h3 className="text-lg font-semibold text-[var(--color-choco)]">โน้ตสำหรับทีมงาน</h3>
+            <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/70">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-lg">🕒</span>
+                <span>จัดรอบอบขนมปังเพิ่มในช่วงบ่าย หากยอดขายยังคงสูงกว่าวันปกติ</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-lg">💬</span>
+                <span>ตอบแชทลูกค้าจาก Facebook &amp; LINE ให้ครบถ้วน เพื่อไม่ให้พลาดโอกาสขาย</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 text-lg">🚚</span>
+                <span>ตรวจสอบที่อยู่จัดส่งใหม่และยืนยันรอบรับสินค้ากับบริษัทขนส่ง</span>
+              </li>
+            </ul>
+          </div>
+
+          <div className="rounded-3xl border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 p-6 text-sm text-[var(--color-choco)]">
+            <h3 className="text-lg font-semibold text-[var(--color-rose-dark)]">ลิงก์ด่วน</h3>
+            <ul className="mt-4 space-y-3">
+              <li>
+                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/products">
+                  ➕ เพิ่มสินค้าใหม่
+                </a>
+              </li>
+              <li>
+                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/orders">
+                  📦 ติดตามคำสั่งซื้อ
+                </a>
+              </li>
+              <li>
+                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/coupons">
+                  🎉 สร้างคูปองโปรโมชัน
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }
 
-function Card({ title, value, accent }) {
+function StatCard({ title, value, caption, accent }) {
   return (
-    <div className="relative overflow-hidden rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f065831a]">
-      <div className={`absolute -top-12 -right-6 h-32 w-32 rounded-full bg-gradient-to-br ${accent} opacity-30`} />
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/90 p-6 shadow-lg shadow-[#f0658314]">
+      <div className={`pointer-events-none absolute -right-10 -top-16 h-36 w-36 rounded-full bg-gradient-to-br ${accent}`} />
       <div className="relative">
-        <div className="text-sm font-medium text-[var(--color-choco)]/70">{title}</div>
-        <div className="mt-4 text-3xl font-semibold text-[var(--color-rose-dark)]">{value}</div>
+        <p className="text-sm font-medium text-[var(--color-choco)]/70">{title}</p>
+        <p className="mt-4 text-3xl font-semibold text-[var(--color-rose-dark)]">{value}</p>
+        <p className="mt-2 text-xs leading-relaxed text-[var(--color-choco)]/60">{caption}</p>
       </div>
     </div>
   );

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -1,6 +1,18 @@
 "use client";
+
 import { useEffect, useMemo, useState } from "react";
 import slugify from "slugify";
+
+const emptyProduct = {
+  title: "",
+  price: 0,
+  stock: 0,
+  description: "",
+  image: "",
+  slug: "",
+  active: true,
+  tags: "",
+};
 
 function toSlug(s) {
   return slugify(String(s || ""), { lower: true, strict: true, trim: true });
@@ -11,25 +23,36 @@ export default function AdminProductsPage() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
   const [editing, setEditing] = useState(null);
-  const [form, setForm] = useState({ title:"", price:0, stock:0, description:"", image:"", slug:"", active:true, tags:"" });
+  const [form, setForm] = useState(emptyProduct);
+  const [search, setSearch] = useState("");
+  const [saving, setSaving] = useState(false);
+
   const isEdit = useMemo(() => Boolean(editing?._id), [editing]);
 
   async function load() {
-    setLoading(true); setErr("");
+    setLoading(true);
+    setErr("");
     try {
       const res = await fetch("/api/products", { cache: "no-store" });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || "Load failed");
       setItems(data);
-    } catch(e){ setErr(String(e.message || e)); }
-    finally { setLoading(false); }
+    } catch (e) {
+      setErr(String(e.message || e));
+    } finally {
+      setLoading(false);
+    }
   }
-  useEffect(() => { load(); }, []);
+
+  useEffect(() => {
+    load();
+  }, []);
 
   function startCreate() {
     setEditing({});
-    setForm({ title:"", price:0, stock:0, description:"", image:"", slug:"", active:true, tags:"" });
+    setForm(emptyProduct);
   }
+
   function startEdit(p) {
     setEditing(p);
     setForm({
@@ -47,14 +70,17 @@ export default function AdminProductsPage() {
   async function onUpload(file) {
     const fd = new FormData();
     fd.append("file", file);
-    const res = await fetch("/api/upload", { method:"POST", body: fd });
+    const res = await fetch("/api/upload", { method: "POST", body: fd });
     const data = await res.json();
     if (!res.ok) throw new Error(data?.error || "Upload failed");
-    setForm(prev => ({ ...prev, image: data.url }));
+    setForm((prev) => ({ ...prev, image: data.url }));
   }
 
   async function onSubmit(e) {
     e.preventDefault();
+    if (saving) return;
+    setSaving(true);
+
     const payload = {
       title: form.title,
       slug: form.slug || toSlug(form.title),
@@ -63,197 +89,340 @@ export default function AdminProductsPage() {
       price: Number(form.price || 0),
       stock: Number(form.stock || 0),
       active: Boolean(form.active),
-      tags: String(form.tags || "").split(",").map(s=>s.trim()).filter(Boolean),
+      tags: String(form.tags || "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
     };
+
     const url = isEdit ? `/api/products/${editing._id}` : "/api/products";
     const method = isEdit ? "PATCH" : "POST";
-    const res = await fetch(url, { method, headers:{ "Content-Type":"application/json" }, body: JSON.stringify(payload) });
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
     const data = await res.json();
-    if (!res.ok) { alert(data?.error || "Save failed"); return; }
-    setEditing(null); await load();
+    setSaving(false);
+    if (!res.ok) {
+      alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ");
+      return;
+    }
+    setEditing(null);
+    await load();
   }
 
   async function onDelete(p) {
     if (!confirm(`ลบสินค้า "${p.title}" ?`)) return;
-    const res = await fetch(`/api/products/${p._id}`, { method:"DELETE" });
+    const res = await fetch(`/api/products/${p._id}`, { method: "DELETE" });
     const data = await res.json();
-    if (!res.ok) { alert(data?.error || "Delete failed"); return; }
+    if (!res.ok) {
+      alert(data?.error || "Delete failed");
+      return;
+    }
     await load();
   }
 
+  async function toggleActive(p) {
+    const newValue = !p.active;
+    const res = await fetch(`/api/products/${p._id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ active: newValue }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data?.error || "Update failed");
+      return;
+    }
+    setItems((prev) => prev.map((x) => (x._id === p._id ? { ...x, active: newValue } : x)));
+  }
+
+  const filteredItems = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return items;
+    return items.filter((p) => {
+      const text = `${p.title} ${p.slug} ${(p.tags || []).join(" ")}`.toLowerCase();
+      return text.includes(term);
+    });
+  }, [items, search]);
+
+  const activeCount = filteredItems.filter((p) => p.active).length;
+  const hiddenCount = filteredItems.length - activeCount;
+
   return (
-    <main className="max-w-6xl mx-auto px-6 py-10">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Products</h1>
-        <button className="px-3 py-2 rounded bg-black text-white" onClick={startCreate}>+ New Product</button>
-      </div>
-
-      {loading && <div className="mt-6">กำลังโหลด...</div>}
-      {err && <div className="mt-6 text-red-600">{err}</div>}
-
-      {!loading && !err && (
-        <div className="mt-6 overflow-x-auto">
-          <table className="min-w-full border rounded-lg overflow-hidden">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="text-left p-3 border-b">รูป</th>
-                <th className="text-left p-3 border-b">ชื่อ</th>
-                <th className="text-left p-3 border-b">ราคา</th>
-                <th className="text-left p-3 border-b">สต็อก</th>
-                <th className="text-left p-3 border-b">สถานะ</th>
-                <th className="text-right p-3 border-b">จัดการ</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((p) => (
-                <tr key={p._id} className="align-top">
-                  <td className="p-3 border-b">
-                    <div className="w-16 h-16 bg-gray-100 rounded overflow-hidden">
-                      {p.images?.[0] ? <img src={p.images[0]} className="w-full h-full object-cover" /> : null}
-                    </div>
-                  </td>
-                  <td className="p-3 border-b">
-                    <div className="font-medium">{p.title}</div>
-                    <div className="text-xs text-gray-500">{p.slug}</div>
-                  </td>
-                  <td className="p-3 border-b">฿{p.price}</td>
-                  <td className="p-3 border-b">{p.stock}</td>
-
-                  {/* Toggle อยู่ในปุ่ม พร้อมข้อความ */}
-                  <td className="p-3 border-b">
-                    <button
-                      onClick={async () => {
-                        const newValue = !p.active;
-                        const res = await fetch(`/api/products/${p._id}`, {
-                          method: "PATCH",
-                          headers: { "Content-Type":"application/json" },
-                          body: JSON.stringify({ active: newValue }),
-                        });
-                        const data = await res.json();
-                        if (!res.ok) { alert(data?.error || "Update failed"); return; }
-                        setItems(prev => prev.map(x => x._id === p._id ? { ...x, active: newValue } : x));
-                      }}
-                      className={`relative inline-flex items-center h-8 w-24 rounded-full transition-colors duration-300 ${
-                        p.active ? "bg-green-500" : "bg-gray-400"
-                      }`}
-                      title={p.active ? "click to hide" : "click to show"}
-                    >
-                      <span
-                        className={`absolute left-1 h-6 w-6 rounded-full bg-white shadow transform transition-transform duration-300 ${
-                          p.active ? "translate-x-16" : "translate-x-0"
-                        }`}
-                      />
-                      <span className="w-full text-center text-xs font-medium text-white select-none">
-                        {p.active ? "active" : "hidden"}
-                      </span>
-                    </button>
-                  </td>
-
-                  <td className="p-3 border-b text-right">
-                    <button className="mr-2 underline" onClick={() => startEdit(p)}>edit</button>
-                    <button className="text-red-600 underline" onClick={() => onDelete(p)}>delete</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <main className="space-y-10">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f0658314] backdrop-blur">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการสินค้า</h2>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              เพิ่ม แก้ไข และควบคุมการแสดงผลสินค้าให้ตรงกับสต็อกจริงในร้าน
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative">
+              <input
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="ค้นหาสินค้า ชื่อ หรือแท็ก"
+                className="w-60 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+              />
+              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-[var(--color-choco)]/50">
+                🔍
+              </span>
+            </div>
+            <button
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)]"
+              onClick={startCreate}
+            >
+              ➕ เพิ่มสินค้าใหม่
+            </button>
+          </div>
         </div>
-      )}
 
-      {/* Drawer / Form */}
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatBubble label="สินค้าทั้งหมด" value={filteredItems.length} tone="from-[#f6c34a]/30 via-[#f78da7]/20 to-transparent" />
+          <StatBubble label="กำลังขาย" value={activeCount} tone="from-[#7cd1b8]/30 via-[#f6c34a]/20 to-transparent" />
+          <StatBubble label="ซ่อนอยู่" value={hiddenCount} tone="from-[#f06583]/30 via-[#f78da7]/20 to-transparent" />
+          <StatBubble label="รอดำเนินการ" value={loading ? "กำลังโหลด" : "พร้อมจัดการ"} tone="from-[#c4b5fd]/30 via-[#f78da7]/10 to-transparent" />
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f0658318]">
+        <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h3>
+            <p className="text-xs text-[var(--color-choco)]/60">
+              อัปเดตสต็อกและราคาได้ทันที ตารางรองรับการเลื่อนในแนวนอนได้บนมือถือ
+            </p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-[var(--color-choco)]/50">
+            {filteredItems.length} รายการที่แสดง
+          </span>
+        </header>
+
+        {loading && <p className="px-6 py-6 text-sm text-[var(--color-choco)]/70">กำลังโหลดข้อมูลสินค้า...</p>}
+        {err && !loading && <p className="px-6 py-6 text-sm text-rose-600">{err}</p>}
+
+        {!loading && !err && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-y-2 px-4 py-4 text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-[var(--color-choco)]/50">
+                  <th className="px-4 py-2">สินค้า</th>
+                  <th className="px-4 py-2">ราคา</th>
+                  <th className="px-4 py-2">สต็อก</th>
+                  <th className="px-4 py-2">สถานะ</th>
+                  <th className="px-4 py-2">แท็ก</th>
+                  <th className="px-4 py-2 text-right">จัดการ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredItems.map((p) => (
+                  <tr key={p._id} className="rounded-3xl bg-white/80 shadow shadow-[#f0658312]">
+                    <td className="px-4 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="h-16 w-16 overflow-hidden rounded-2xl bg-[#fff1dd]">
+                          {p.images?.[0] ? (
+                            <img src={p.images[0]} alt={p.title} className="h-full w-full object-cover" />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center text-xs text-[var(--color-choco)]/40">
+                              ไม่มีรูป
+                            </div>
+                          )}
+                        </div>
+                        <div>
+                          <p className="font-semibold text-[var(--color-choco)]">{p.title}</p>
+                          <p className="text-xs text-[var(--color-choco)]/50">{p.slug}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 font-semibold text-[var(--color-choco)]">฿{p.price}</td>
+                    <td className="px-4 py-4 text-[var(--color-choco)]">{p.stock}</td>
+                    <td className="px-4 py-4">
+                      <button
+                        onClick={() => toggleActive(p)}
+                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition ${
+                          p.active
+                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
+                            : "bg-gray-200 text-gray-500"
+                        }`}
+                        title={p.active ? "คลิกเพื่อซ่อนสินค้า" : "คลิกเพื่อแสดงสินค้า"}
+                      >
+                        <span className="text-base">{p.active ? "🟢" : "⚪️"}</span>
+                        {p.active ? "กำลังขาย" : "ซ่อนอยู่"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-4 text-xs text-[var(--color-choco)]/60">
+                      {Array.isArray(p.tags) && p.tags.length > 0 ? p.tags.join(", ") : "-"}
+                    </td>
+                    <td className="px-4 py-4 text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          className="rounded-full border border-[var(--color-rose)]/40 px-4 py-1 text-xs font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-[var(--color-rose)]/10"
+                          onClick={() => startEdit(p)}
+                        >
+                          แก้ไข
+                        </button>
+                        <button
+                          className="rounded-full border border-rose-200 px-4 py-1 text-xs font-semibold text-rose-500 transition hover:border-rose-400 hover:bg-rose-100"
+                          onClick={() => onDelete(p)}
+                        >
+                          ลบ
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
       {editing !== null && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-2xl w-full max-w-2xl p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">{isEdit ? "Edit product" : "New product"}</h2>
-              <button className="text-sm underline" onClick={() => setEditing(null)}>close</button>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
+          <div className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/80 bg-white/95 shadow-2xl shadow-[#f0658330]">
+            <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
+              <div>
+                <h3 className="text-lg font-semibold text-[var(--color-choco)]">
+                  {isEdit ? "แก้ไขสินค้า" : "เพิ่มสินค้าใหม่"}
+                </h3>
+                <p className="text-xs text-[var(--color-choco)]/60">
+                  กรอกข้อมูลให้ครบถ้วนเพื่อให้หน้าเว็บแสดงผลสวยงามและถูกต้อง
+                </p>
+              </div>
+              <button
+                className="rounded-full border border-[var(--color-choco)]/10 bg-white px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/30 hover:text-[var(--color-choco)]"
+                onClick={() => setEditing(null)}
+              >
+                ปิด
+              </button>
             </div>
 
-            <form onSubmit={onSubmit} className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-3">
-                <div>
-                  <label className="text-sm block mb-1">ชื่อสินค้า</label>
+            <form onSubmit={onSubmit} className="grid gap-6 px-6 py-6 md:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-4">
+                <Field label="ชื่อสินค้า" required>
                   <input
-                    className="w-full border rounded px-3 py-2"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.title}
-                    onChange={(e)=> setForm(f => ({...f, title:e.target.value, slug: toSlug(e.target.value)}))}
-                    required
+                    onChange={(e) =>
+                      setForm((f) => ({
+                        ...f,
+                        title: e.target.value,
+                        slug: f.slug ? f.slug : toSlug(e.target.value),
+                      }))
+                    }
                   />
-                </div>
-                <div>
-                  <label className="text-sm block mb-1">Slug</label>
-                  <input className="w-full border rounded px-3 py-2"
+                </Field>
+                <Field label="Slug">
+                  <input
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.slug}
-                    onChange={(e)=> setForm(f => ({...f, slug:e.target.value}))}
+                    onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
                   />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-sm block mb-1">ราคา</label>
-                    <input type="number" className="w-full border rounded px-3 py-2"
-                      value={form.price} min={0}
-                      onChange={(e)=> setForm(f => ({...f, price:Number(e.target.value || 0)}))}
+                </Field>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field label="ราคา">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                      value={form.price}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, price: Number(e.target.value || 0) }))
+                      }
                     />
-                  </div>
-                  <div>
-                    <label className="text-sm block mb-1">สต็อก</label>
-                    <input type="number" className="w-full border rounded px-3 py-2"
-                      value={form.stock} min={0}
-                      onChange={(e)=> setForm(f => ({...f, stock:Number(e.target.value || 0)}))}
+                  </Field>
+                  <Field label="สต็อก">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                      value={form.stock}
+                      onChange={(e) =>
+                        setForm((f) => ({ ...f, stock: Number(e.target.value || 0) }))
+                      }
                     />
-                  </div>
+                  </Field>
                 </div>
-                <div>
-                  <label className="text-sm block mb-1">แท็ก (คั่นด้วย ,)</label>
-                  <input className="w-full border rounded px-3 py-2"
+                <Field label="แท็ก (คั่นด้วย ,)">
+                  <input
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.tags}
-                    onChange={(e)=> setForm(f => ({...f, tags:e.target.value}))}
+                    onChange={(e) => setForm((f) => ({ ...f, tags: e.target.value }))}
                   />
-                </div>
-                <div className="flex items-center gap-2">
-                  <input id="active" type="checkbox" checked={form.active}
-                    onChange={(e)=> setForm(f => ({...f, active:e.target.checked}))}/>
-                  <label htmlFor="active" className="text-sm">แสดงสินค้า</label>
-                </div>
+                </Field>
+                <label className="flex items-center gap-3 text-sm font-medium text-[var(--color-choco)]/80">
+                  <input
+                    type="checkbox"
+                    checked={form.active}
+                    onChange={(e) => setForm((f) => ({ ...f, active: e.target.checked }))}
+                    className="h-4 w-4 rounded border-[var(--color-rose)]/40 text-[var(--color-rose)] focus:ring-[var(--color-rose)]"
+                  />
+                  แสดงสินค้าบนหน้าร้าน
+                </label>
               </div>
 
-              <div className="space-y-3">
-                <div>
-                  <label className="text-sm block mb-1">คำอธิบาย</label>
-                  <textarea className="w-full border rounded px-3 py-2 h-28"
+              <div className="space-y-4">
+                <Field label="คำอธิบาย">
+                  <textarea
+                    className="h-32 w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                     value={form.description}
-                    onChange={(e)=> setForm(f => ({...f, description:e.target.value}))}
+                    onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
                   />
-                </div>
-                <div>
-                  <label className="text-sm block mb-1">รูปสินค้า</label>
-                  <div className="flex items-center gap-3">
-                    <div className="w-24 h-24 bg-gray-100 rounded overflow-hidden">
-                      {form.image ? <img src={form.image} className="w-full h-full object-cover" /> : null}
+                </Field>
+                <Field label="รูปสินค้า">
+                  <div className="flex flex-col gap-4 sm:flex-row">
+                    <div className="h-28 w-28 overflow-hidden rounded-2xl border border-white/70 bg-[#fff1dd] shadow-inner">
+                      {form.image ? (
+                        <img src={form.image} alt="preview" className="h-full w-full object-cover" />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-xs text-[var(--color-choco)]/50">
+                          รออัปโหลด
+                        </div>
+                      )}
                     </div>
-                    <div className="flex-1">
-                      <input type="file" accept="image/*"
+                    <div className="flex-1 space-y-3 text-sm">
+                      <input
+                        type="file"
+                        accept="image/*"
                         onChange={async (e) => {
                           const file = e.target.files?.[0];
                           if (!file) return;
-                          try { await onUpload(file); }
-                          catch (err) { alert(String(err.message || err)); }
+                          try {
+                            await onUpload(file);
+                          } catch (error) {
+                            alert(String(error.message || error));
+                          }
                         }}
+                        className="w-full rounded-2xl border border-dashed border-[var(--color-rose)]/40 bg-white/70 px-4 py-3 text-sm text-[var(--color-choco)]/70 file:mr-4 file:rounded-full file:border-0 file:bg-[var(--color-rose)]/10 file:px-4 file:py-2 file:text-[var(--color-rose)]"
                       />
-                      <input className="mt-2 w-full border rounded px-3 py-2"
-                        placeholder="หรือวาง URL รูป"
+                      <input
+                        className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                        placeholder="หรือวาง URL รูปสินค้า"
                         value={form.image}
-                        onChange={(e)=> setForm(f => ({...f, image:e.target.value}))}
+                        onChange={(e) => setForm((f) => ({ ...f, image: e.target.value }))}
                       />
                     </div>
                   </div>
-                </div>
-                <div className="pt-2 flex items-center gap-3">
-                  <button className="px-4 py-2 rounded bg-black text-white">
-                    {isEdit ? "บันทึก" : "สร้างสินค้า"}
-                  </button>
-                  <button type="button" className="px-4 py-2 rounded border" onClick={() => setEditing(null)}>
+                </Field>
+
+                <div className="flex flex-wrap justify-end gap-3 pt-2">
+                  <button
+                    type="button"
+                    className="rounded-full border border-[var(--color-choco)]/20 px-5 py-2 text-sm font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/40 hover:text-[var(--color-choco)]"
+                    onClick={() => setEditing(null)}
+                  >
                     ยกเลิก
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={saving}
+                  >
+                    {saving ? "กำลังบันทึก..." : isEdit ? "บันทึกการแก้ไข" : "สร้างสินค้า"}
                   </button>
                 </div>
               </div>
@@ -262,5 +431,29 @@ export default function AdminProductsPage() {
         </div>
       )}
     </main>
+  );
+}
+
+function Field({ label, required, children }) {
+  return (
+    <label className="block text-sm font-medium text-[var(--color-choco)]/80">
+      <span className="mb-2 block">
+        {label}
+        {required ? <span className="ml-1 text-rose-500">*</span> : null}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function StatBubble({ label, value, tone }) {
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/70 bg-white/80 p-4 text-sm font-semibold text-[var(--color-choco)] shadow-inner">
+      <div className={`pointer-events-none absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br ${tone}`} />
+      <div className="relative">
+        <p className="text-xs uppercase tracking-wide text-[var(--color-choco)]/50">{label}</p>
+        <p className="mt-2 text-xl text-[var(--color-rose-dark)]">{value}</p>
+      </div>
+    </div>
   );
 }

--- a/app/api/checkout/preview/route.js
+++ b/app/api/checkout/preview/route.js
@@ -59,6 +59,20 @@ export async function POST(req) {
       });
     }
 
+    if (method === "bank") {
+      return NextResponse.json({
+        ok: 1,
+        method,
+        orderPreview: { items: checked, subtotal, discount, total, coupon: used },
+        bankAccount: {
+          name: process.env.BANK_ACCOUNT_NAME || "บจก. Sweet Cravings",
+          number: process.env.BANK_ACCOUNT_NUMBER || "123-4-567890",
+          bank: process.env.BANK_ACCOUNT_BANK || "ธนาคารตัวอย่าง",
+          promptpayId: process.env.PROMPTPAY_ID || "",
+        },
+      });
+    }
+
     return NextResponse.json({ error: "Unknown payment method" }, { status: 400 });
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });

--- a/app/api/checkout/preview/route.js
+++ b/app/api/checkout/preview/route.js
@@ -3,6 +3,7 @@ import { connectToDatabase } from "@/lib/db";
 import { Product } from "@/models/Product";
 import { promptPayPayload } from "@/lib/promptpay";
 import { Coupon } from "@/models/Coupon";
+import { getPaymentConfig } from "@/lib/paymentConfig";
 
 function calcDiscount(coupon, subtotal) {
   if (!coupon) return { discount: 0, used: null };
@@ -48,8 +49,10 @@ export async function POST(req) {
     const { discount, used } = calcDiscount(coupon, subtotal);
     const total = subtotal - discount;
 
+    const { promptpayId, bankAccount } = getPaymentConfig();
+
     if (method === "promptpay") {
-      const payload = promptPayPayload({ id: process.env.PROMPTPAY_ID, amount: total });
+      const payload = promptPayPayload({ id: promptpayId, amount: total });
       // ❗️ พรีวิว: ไม่สร้างออเดอร์, ไม่ตัดสต็อก — แค่ส่งข้อมูลกลับ
       return NextResponse.json({
         ok: 1,
@@ -64,12 +67,7 @@ export async function POST(req) {
         ok: 1,
         method,
         orderPreview: { items: checked, subtotal, discount, total, coupon: used },
-        bankAccount: {
-          name: process.env.BANK_ACCOUNT_NAME || "บจก. Sweet Cravings",
-          number: process.env.BANK_ACCOUNT_NUMBER || "123-4-567890",
-          bank: process.env.BANK_ACCOUNT_BANK || "ธนาคารตัวอย่าง",
-          promptpayId: process.env.PROMPTPAY_ID || "",
-        },
+        bankAccount,
       });
     }
 

--- a/app/api/checkout/route.js
+++ b/app/api/checkout/route.js
@@ -3,6 +3,9 @@ import { connectToDatabase } from "@/lib/db";
 import { Product } from "@/models/Product";
 import { promptPayPayload } from "@/lib/promptpay";
 import { Coupon } from "@/models/Coupon"; // ⬅️ เพิ่ม
+import { Order } from "@/models/Order";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 function calcDiscount(coupon, subtotal) {
   if (!coupon) return { discount: 0, used: null };
@@ -19,7 +22,13 @@ function calcDiscount(coupon, subtotal) {
 
 export async function POST(req) {
   try {
-    const { items, method = "promptpay", couponCode } = await req.json();
+    const {
+      items,
+      method = "promptpay",
+      couponCode,
+      customer = {},
+      shipping = {},
+    } = await req.json();
 
     if (!Array.isArray(items) || items.length === 0) {
       return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
@@ -49,17 +58,66 @@ export async function POST(req) {
     const { discount, used } = calcDiscount(coupon, subtotal);
     const total = subtotal - discount;
 
-    if (method === "promptpay") {
-      const payload = promptPayPayload({ id: process.env.PROMPTPAY_ID, amount: total });
-      return NextResponse.json({
-        ok: 1,
-        method,
-        orderPreview: { items: checked, subtotal, discount, total, coupon: used },
-        promptpay: { payload, amount: total },
-      });
+    const allowedMethods = ["promptpay", "bank"];
+    if (!allowedMethods.includes(method)) {
+      return NextResponse.json({ error: "Unknown payment method" }, { status: 400 });
     }
 
-    return NextResponse.json({ error: "Unknown payment method" }, { status: 400 });
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id || null;
+
+    const paymentStatus = total > 0 ? "pending" : "paid";
+
+    const order = await Order.create({
+      userId,
+      items: checked.map(({ lineTotal, ...rest }) => rest),
+      subtotal,
+      discount,
+      total,
+      coupon: used,
+      customer: {
+        name: String(customer?.name || ""),
+        phone: String(customer?.phone || ""),
+        email: String(customer?.email || ""),
+      },
+      shipping: {
+        address1: String(shipping?.address1 || ""),
+        address2: String(shipping?.address2 || ""),
+        district: String(shipping?.district || ""),
+        province: String(shipping?.province || ""),
+        postcode: String(shipping?.postcode || ""),
+        note: String(shipping?.note || ""),
+      },
+      payment: { method, status: paymentStatus, ref: "" },
+      status: "new",
+    });
+
+    const promptpayData =
+      method === "promptpay" && total > 0
+        ? {
+            payload: promptPayPayload({ id: process.env.PROMPTPAY_ID, amount: total }),
+            amount: total,
+          }
+        : null;
+
+    const bankAccount =
+      method === "bank"
+        ? {
+            name: process.env.BANK_ACCOUNT_NAME || "บจก. Sweet Cravings",
+            number: process.env.BANK_ACCOUNT_NUMBER || "123-4-567890",
+            bank: process.env.BANK_ACCOUNT_BANK || "ธนาคารตัวอย่าง",
+            promptpayId: process.env.PROMPTPAY_ID || "", // เผื่อใช้สแกนด้วยพร้อมเพย์
+          }
+        : null;
+
+    return NextResponse.json({
+      ok: 1,
+      method,
+      orderId: String(order._id),
+      orderPreview: { items: checked, subtotal, discount, total, coupon: used },
+      promptpay: promptpayData,
+      bankAccount,
+    });
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });
   }

--- a/app/api/my/orders/[id]/route.js
+++ b/app/api/my/orders/[id]/route.js
@@ -3,6 +3,7 @@ import { connectToDatabase } from "@/lib/db";
 import { Order } from "@/models/Order";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { serializeOrder } from "@/lib/serializeOrder";
 
 export async function GET(_req, { params }) {
   const { id } = await params; // Next 15 ต้อง await
@@ -13,5 +14,5 @@ export async function GET(_req, { params }) {
   await connectToDatabase();
   const order = await Order.findOne({ _id: id, userId: session.user.id }).lean();
   if (!order) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(order);
+  return NextResponse.json(serializeOrder(order, { includeSlip: true }));
 }

--- a/app/api/my/orders/route.js
+++ b/app/api/my/orders/route.js
@@ -3,6 +3,7 @@ import { connectToDatabase } from "@/lib/db";
 import { Order } from "@/models/Order";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { serializeOrder } from "@/lib/serializeOrder";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -13,5 +14,6 @@ export async function GET() {
   const orders = await Order.find({ userId: session.user.id })
     .sort({ createdAt: -1 })
     .lean();
-  return NextResponse.json(orders);
+  const sanitized = orders.map((order) => serializeOrder(order));
+  return NextResponse.json(sanitized);
 }

--- a/app/api/orders/[id]/confirm/route.js
+++ b/app/api/orders/[id]/confirm/route.js
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "@/lib/db";
+import { Order } from "@/models/Order";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+function isValidDataUrl(str) {
+  if (typeof str !== "string") return false;
+  return /^data:image\/(png|jpe?g|gif|webp);base64,/.test(str.trim());
+}
+
+function parseAmountInput(value) {
+  if (value === null || value === undefined) return NaN;
+  const raw = String(value).trim();
+  if (!raw) return NaN;
+  const digits = raw.replace(/[^0-9.,]/g, "");
+  if (!digits) return NaN;
+
+  const hasComma = digits.includes(",");
+  const hasDot = digits.includes(".");
+
+  if (hasComma && hasDot) {
+    const separatorIndex = Math.max(digits.lastIndexOf(","), digits.lastIndexOf("."));
+    const integerPart = digits.slice(0, separatorIndex).replace(/[^0-9]/g, "");
+    const decimalPart = digits.slice(separatorIndex + 1).replace(/[^0-9]/g, "");
+    if (!integerPart && !decimalPart) return NaN;
+    const normalizedInteger = integerPart || "0";
+    const normalizedDecimal = decimalPart ? decimalPart.slice(0, 2) : "0";
+    return Number(`${normalizedInteger}.${normalizedDecimal}`);
+  }
+
+  const separator = hasComma ? "," : hasDot ? "." : null;
+  if (!separator) {
+    return Number(digits.replace(/[^0-9]/g, ""));
+  }
+
+  const parts = digits.split(separator);
+  if (parts.length === 2 && parts[1].replace(/[^0-9]/g, "").length <= 2) {
+    const integerPart = parts[0].replace(/[^0-9]/g, "") || "0";
+    const decimalPart = parts[1].replace(/[^0-9]/g, "");
+    return Number(`${integerPart}.${decimalPart.slice(0, 2)}`);
+  }
+
+  return Number(digits.replace(/[^0-9]/g, ""));
+}
+
+export async function POST(req, { params }) {
+  try {
+    const orderId = params?.id;
+    if (!orderId) {
+      return NextResponse.json({ error: "Missing order id" }, { status: 400 });
+    }
+
+    const body = await req.json();
+    const { slip, filename = "", amount, reference = "" } = body || {};
+
+    if (!isValidDataUrl(slip)) {
+      return NextResponse.json({ error: "ต้องแนบสลิปการโอนเป็นไฟล์ภาพ" }, { status: 400 });
+    }
+
+    // Limit slip payload size (about 5MB of base64)
+    if (slip.length > 7_000_000) {
+      return NextResponse.json({ error: "ไฟล์สลิปมีขนาดใหญ่เกินไป (สูงสุด ~5MB)" }, { status: 413 });
+    }
+
+    await connectToDatabase();
+
+    const order = await Order.findById(orderId);
+    if (!order) {
+      return NextResponse.json({ error: "ไม่พบคำสั่งซื้อ" }, { status: 404 });
+    }
+
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (order.userId && userId && String(order.userId) !== String(userId)) {
+      return NextResponse.json({ error: "ไม่สามารถยืนยันคำสั่งซื้อนี้" }, { status: 403 });
+    }
+
+    const expected = Number(order.total || 0);
+    let paidAmount = 0;
+
+    if (expected > 0) {
+      const parsedAmount = parseAmountInput(amount);
+      if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+        return NextResponse.json({ error: "กรุณากรอกจำนวนเงินที่โอน" }, { status: 400 });
+      }
+
+      paidAmount = Number(parsedAmount.toFixed(2));
+      const tolerance = 0.5;
+      if (Math.abs(paidAmount - expected) > tolerance) {
+        return NextResponse.json(
+          {
+            error: `ยอดโอน ${paidAmount.toFixed(2)} บาท ไม่ตรงกับยอดที่ต้องชำระ ${expected.toFixed(2)} บาท กรุณาตรวจสอบอีกครั้ง`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    order.payment = {
+      ...order.payment,
+      slip,
+      slipFilename: String(filename || "").slice(0, 120),
+      confirmedAt: new Date(),
+      status: "paid",
+      amountPaid: paidAmount,
+      ref: String(reference || "").slice(0, 120),
+    };
+
+    await order.save();
+
+    return NextResponse.json({ ok: 1, orderId: String(order._id) });
+  } catch (e) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -53,7 +53,12 @@ export async function POST(req) {
       userId,
       items: checked.map(({ lineTotal, ...rest }) => rest),
       subtotal, discount, total,
-      payment: { method: payment.method, status: payment.status || "pending", ref: payment.ref || "" },
+      payment: {
+        method: payment.method || "promptpay",
+        status: payment.status || "pending",
+        ref: payment.ref || "",
+        amountPaid: payment.amountPaid || 0,
+      },
       status: "new",
     });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,5 +3,39 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ตัวเลือก: ฟอนต์ทั้งเว็บ */
-html, body { height: 100%; }
+:root {
+  --color-cream: #fff7f0;
+  --color-rose: #f06583;
+  --color-rose-dark: #db4568;
+  --color-gold: #f6c34a;
+  --color-choco: #4f2b1d;
+  --layout-max: 1200px;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-cream);
+  color: var(--color-choco);
+  font-family: "Poppins", "Prompt", "Kanit", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: var(--color-rose);
+}
+
+a:hover {
+  color: var(--color-rose-dark);
+}
+
+::selection {
+  background: rgba(240, 101, 131, 0.25);
+}
+
+label {
+  color: rgba(79, 43, 29, 0.85);
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,18 +1,16 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
-const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
-
 export const metadata = {
-  title: "Bun Shop",
-  description: "Minimal bakery shop",
+  title: "Sweet Cravings Bakery",
+  description: "เบเกอรี่โฮมเมด กลิ่นหอมอบอุ่น พร้อมส่งถึงบ้านคุณ",
 };
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="th" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body className="text-gray-900">{children}</body>
+    <html lang="th">
+      <body className="min-h-screen bg-[var(--color-cream)] text-[var(--color-choco)]">
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -5,10 +5,15 @@ export default function AddToCartButton({ product }) {
   const cart = useCart();
   return (
     <button
-      className="px-3 py-2 rounded-lg bg-black text-white"
-      onClick={() => cart.add({ productId: product._id, title: product.title, price: product.price }, 1)}
+      className="px-4 py-2 rounded-full bg-gradient-to-r from-[#f06583] to-[#f78da7] text-white text-sm font-semibold shadow-lg shadow-[#f0658333] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+      onClick={() =>
+        cart.add(
+          { productId: product._id, title: product.title, price: product.price },
+          1,
+        )
+      }
     >
-      Add to cart
+      เพิ่มลงตะกร้า
     </button>
   );
 }

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -2,66 +2,187 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
+import { useState, useEffect } from "react";
+
+const navItems = [
+  { href: "/", label: "หน้าหลัก" },
+  { href: "/cart", label: "ตะกร้า" },
+  { href: "/orders", label: "คำสั่งซื้อ" },
+];
 
 export default function NavBar() {
   const path = usePathname();
-  const { data: session, status } = useSession(); // session?.user?.role
+  const { data: session, status } = useSession();
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  const link = (href, label) => (
-    <Link
-      href={href}
-      className={`hover:underline ${path === href ? "font-semibold" : ""}`}
-    >
-      {label}
-    </Link>
-  );
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [path]);
+
+  const link = (href, label, key) => {
+    const active = path === href;
+    return (
+      <Link
+        key={key}
+        href={href}
+        className={`px-3 py-2 rounded-full text-sm font-medium transition-colors duration-200 ${
+          active
+            ? "bg-white/80 text-[var(--color-rose)] shadow"
+            : "text-[var(--color-choco)] hover:text-[var(--color-rose)]"
+        }`}
+      >
+        {label}
+      </Link>
+    );
+  };
 
   return (
-    <nav className="border-b">
-      <div className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
-        <Link href="/" className="font-bold">Bun Shop</Link>
+    <header className="sticky top-0 z-30 backdrop-blur bg-[var(--color-cream)]/70">
+      <div className="hidden md:flex items-center justify-between px-6 py-2 text-xs text-[var(--color-choco)]/80 max-w-screen-xl mx-auto">
+        <span>อบสดใหม่ทุกวัน • ส่งฟรีในเมืองเมื่อสั่งครบ ฿800</span>
+        <a href="tel:021234567" className="font-medium hover:text-[var(--color-rose)]">
+          โทร. 02-123-4567
+        </a>
+      </div>
 
-        <div className="flex items-center gap-4">
-          {link("/cart", "Cart")}
+      <nav className="bg-gradient-to-r from-[#ffe1c9] via-[#ffe9d6] to-[#ffe1ea] shadow-md">
+        <div className="max-w-screen-xl mx-auto px-4 sm:px-6">
+          <div className="flex items-center justify-between py-4">
+            <Link href="/" className="flex items-center gap-2">
+              <div className="h-10 w-10 rounded-full bg-white/90 shadow-inner flex items-center justify-center text-xl">
+                🥐
+              </div>
+              <span className="text-xl sm:text-2xl font-extrabold text-[var(--color-rose-dark)] tracking-tight">
+                Sweet Cravings
+              </span>
+            </Link>
 
-          {/* รอโหลด session */}
-          {status === "loading" && <span className="text-gray-500 text-sm">loading…</span>}
+            <button
+              className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/80 text-[var(--color-rose-dark)] shadow transition hover:bg-white"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-label="Toggle menu"
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-6 w-6"
+              >
+                {menuOpen ? (
+                  <path
+                    fillRule="evenodd"
+                    d="M6.225 4.811a.75.75 0 011.06 0L12 9.525l4.715-4.714a.75.75 0 111.06 1.06L13.06 10.585l4.715 4.714a.75.75 0 11-1.06 1.061L12 11.646l-4.715 4.714a.75.75 0 11-1.06-1.06L10.94 10.585 6.225 5.87a.75.75 0 010-1.06z"
+                    clipRule="evenodd"
+                  />
+                ) : (
+                  <path
+                    fillRule="evenodd"
+                    d="M3.75 5.25A.75.75 0 014.5 4.5h15a.75.75 0 010 1.5h-15a.75.75 0 01-.75-.75zm0 6A.75.75 0 014.5 10.5h15a.75.75 0 010 1.5h-15a.75.75 0 01-.75-.75zm0 6a.75.75 0 01.75-.75h15a.75.75 0 010 1.5h-15a.75.75 0 01-.75-.75z"
+                    clipRule="evenodd"
+                  />
+                )}
+              </svg>
+            </button>
 
-          {/* ถ้ายังไม่ล็อกอิน */}
-          {status === "unauthenticated" && (
-            <>
-              {link("/login", "Login")}
-              {link("/register", "Register")}
-            </>
-          )}
-
-          {/* ถ้าล็อกอินแล้ว */}
-          {status === "authenticated" && (
-            <>
-              {/* โชว์ปุ่ม Admin เฉพาะ role=admin */}
-              {session?.user?.role === "admin" && (
-                <Link
-                  href="/admin"
-                  className="px-3 py-1.5 rounded bg-gray-900 text-white"
-                >
-                  Admin
-                </Link>
+            <div className="hidden md:flex items-center gap-3">
+              {navItems.map(({ href, label }) => link(href, label, href))}
+              {status === "loading" && (
+                <span className="text-xs text-[var(--color-choco)]/70">กำลังโหลด...</span>
               )}
 
-              {/* โปรไฟล์/ออกจากระบบ (ตัวอย่างง่าย) */}
-              <span className="text-sm text-gray-700">
-                {session.user.name || session.user.email}
-              </span>
-              <button
-                onClick={() => signOut({ callbackUrl: "/" })}
-                className="text-sm underline"
-              >
-                Logout
-              </button>
-            </>
-          )}
+              {status === "unauthenticated" && (
+                <div className="flex items-center gap-2">
+                  <Link
+                    href="/login"
+                    className="px-4 py-2 rounded-full text-sm font-medium bg-white/70 text-[var(--color-rose-dark)] shadow hover:bg-white"
+                  >
+                    เข้าสู่ระบบ
+                  </Link>
+                  <Link
+                    href="/register"
+                    className="px-4 py-2 rounded-full text-sm font-medium text-white bg-[var(--color-rose)] shadow-lg hover:bg-[var(--color-rose-dark)]"
+                  >
+                    สมัครสมาชิก
+                  </Link>
+                </div>
+              )}
+
+              {status === "authenticated" && (
+                <div className="flex items-center gap-3 text-sm">
+                  {session?.user?.role === "admin" && (
+                    <Link
+                      href="/admin"
+                      className="px-4 py-2 rounded-full bg-white/80 text-[var(--color-rose-dark)] shadow hover:bg-white"
+                    >
+                      จัดการร้าน
+                    </Link>
+                  )}
+                  <span className="text-[var(--color-choco)]/80">
+                    {session?.user?.name || session?.user?.email}
+                  </span>
+                  <button
+                    onClick={() => signOut({ callbackUrl: "/" })}
+                    className="text-[var(--color-rose-dark)] underline decoration-dotted"
+                  >
+                    ออกจากระบบ
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
-    </nav>
+
+        <div
+          className={`md:hidden transition-all duration-200 ${
+            menuOpen ? "max-h-screen opacity-100" : "max-h-0 opacity-0"
+          } overflow-hidden bg-white/80 backdrop-blur`}
+        >
+          <div className="px-6 pb-6 flex flex-col gap-3 text-sm text-[var(--color-choco)]">
+            {navItems.map(({ href, label }) => link(href, label, href))}
+            {status === "loading" && (
+              <span className="text-xs text-[var(--color-choco)]/70">กำลังโหลด...</span>
+            )}
+            {status === "unauthenticated" && (
+              <div className="flex flex-col gap-2">
+                <Link
+                  href="/login"
+                  className="px-4 py-2 rounded-full font-medium bg-white text-[var(--color-rose-dark)] shadow"
+                >
+                  เข้าสู่ระบบ
+                </Link>
+                <Link
+                  href="/register"
+                  className="px-4 py-2 rounded-full font-medium text-white bg-[var(--color-rose)] shadow"
+                >
+                  สมัครสมาชิก
+                </Link>
+              </div>
+            )}
+            {status === "authenticated" && (
+              <div className="flex flex-col gap-3">
+                {session?.user?.role === "admin" && (
+                  <Link
+                    href="/admin"
+                    className="px-4 py-2 rounded-full font-medium bg-white text-[var(--color-rose-dark)] shadow"
+                  >
+                    จัดการร้าน
+                  </Link>
+                )}
+                <span className="text-[var(--color-choco)]/70">
+                  {session?.user?.name || session?.user?.email}
+                </span>
+                <button
+                  onClick={() => signOut({ callbackUrl: "/" })}
+                  className="text-left text-[var(--color-rose-dark)] underline"
+                >
+                  ออกจากระบบ
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </nav>
+    </header>
   );
 }

--- a/components/QrBox.jsx
+++ b/components/QrBox.jsx
@@ -5,6 +5,7 @@ import QRCode from "qrcode";
 export default function QrBox({ payload, amount, title = "สแกนจ่าย PromptPay" }) {
   const canvasRef = useRef(null);
   const [err, setErr] = useState("");
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (!payload || !canvasRef.current) return;
@@ -15,6 +16,7 @@ export default function QrBox({ payload, amount, title = "สแกนจ่า�
           width: 240,
           margin: 1,
           errorCorrectionLevel: "M",
+          color: { dark: "#4f2b1d", light: "#ffffff" },
         });
       } catch (e) {
         setErr(String(e.message || e));
@@ -22,30 +24,39 @@ export default function QrBox({ payload, amount, title = "สแกนจ่า�
     })();
   }, [payload]);
 
-  return (
-    <div className="border rounded-xl p-4 bg-white">
-      <div className="font-semibold mb-1">{title}</div>
-      <div className="text-sm text-gray-600">จำนวนเงิน: ฿{amount}</div>
+  async function copyPayload() {
+    try {
+      await navigator.clipboard.writeText(payload);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (copyErr) {
+      setErr(String(copyErr?.message || copyErr || "คัดลอกไม่สำเร็จ"));
+    }
+  }
 
-      {/* QR */}
-      <div className="mt-3 flex items-center justify-center">
-        <canvas ref={canvasRef} />
+  return (
+    <div className="rounded-3xl bg-white p-6 text-center shadow-lg shadow-[#f065831a]">
+      <div className="text-lg font-semibold text-[var(--color-choco)]">{title}</div>
+      <div className="mt-1 text-sm text-[var(--color-choco)]/70">จำนวนเงิน: ฿{amount}</div>
+
+      <div className="mt-4 flex items-center justify-center">
+        <canvas ref={canvasRef} className="rounded-2xl border border-[#f7b267]/40 bg-white p-3" />
       </div>
 
-      {/* payload + copy */}
-      <div className="mt-3">
-        <div className="text-xs text-gray-500 break-all bg-gray-50 border rounded p-2">
+      <div className="mt-4 space-y-2 text-left">
+        <div className="rounded-2xl border border-[#f7b267]/40 bg-[#fff8f1] p-3 text-xs text-[var(--color-choco)]/80 break-all">
           {payload}
         </div>
         <button
-          className="mt-2 text-sm underline"
-          onClick={() => navigator.clipboard.writeText(payload)}
+          className="w-full rounded-full bg-gradient-to-r from-[#f06583] to-[#f78da7] px-4 py-2 text-sm font-semibold text-white shadow shadow-[#f0658333] transition hover:shadow-md"
+          onClick={copyPayload}
+          type="button"
         >
-          คัดลอกโค้ด
+          {copied ? "คัดลอกแล้ว" : "คัดลอกโค้ด"}
         </button>
       </div>
 
-      {err && <div className="text-red-600 text-sm mt-2">{err}</div>}
+      {err && <div className="mt-3 text-sm text-rose-600">{err}</div>}
     </div>
   );
 }

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -22,7 +22,10 @@ export default function AdminSidebar() {
   const nav = useMemo(
     () =>
       items.map((it) => {
-        const active = path === it.href || path?.startsWith(`${it.href}/`);
+        const active =
+          it.href === "/admin"
+            ? path === it.href
+            : path === it.href || path?.startsWith(`${it.href}/`);
         return (
           <Link
             key={it.href}

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -1,37 +1,111 @@
 "use client";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const items = [
-  { href: "/admin", label: "Dashboard" },
-  { href: "/admin/products", label: "Products" },
-  { href: "/admin/orders", label: "Orders" },
-  { href: "/admin/coupons", label: "Coupons" },
+  { href: "/admin", label: "แดชบอร์ด", icon: "📊" },
+  { href: "/admin/products", label: "จัดการสินค้า", icon: "🧁" },
+  { href: "/admin/orders", label: "คำสั่งซื้อ", icon: "🧾" },
+  { href: "/admin/coupons", label: "คูปอง", icon: "🎟️" },
 ];
 
 export default function AdminSidebar() {
   const path = usePathname();
+  const [open, setOpen] = useState(false);
+
+  // ปิดเมนูเมื่อเปลี่ยนเส้นทาง เพื่อไม่ให้เมนูค้างอยู่บนมือถือ
+  useEffect(() => {
+    setOpen(false);
+  }, [path]);
+
+  const nav = useMemo(
+    () =>
+      items.map((it) => {
+        const active = path === it.href || path?.startsWith(`${it.href}/`);
+        return (
+          <Link
+            key={it.href}
+            href={it.href}
+            className={`group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold tracking-wide transition ${
+              active
+                ? "bg-white text-[var(--color-rose-dark)] shadow-lg shadow-[#f0658333]"
+                : "text-white/80 hover:bg-white/15 hover:text-white"
+            }`}
+          >
+            <span className="text-base transition-transform group-hover:scale-110">{it.icon}</span>
+            {it.label}
+          </Link>
+        );
+      }),
+    [path]
+  );
+
   return (
-    <aside className="w-64 shrink-0 bg-gradient-to-b from-[#f06583] to-[#f78da7] text-white shadow-2xl">
-      <div className="h-16 flex items-center px-6 text-lg font-semibold tracking-wide">
-        🍰 Admin Suite
-      </div>
-      <nav className="px-4 pb-6 space-y-2">
-        {items.map((it) => {
-          const active = path === it.href;
-          return (
-            <Link
-              key={it.href}
-              href={it.href}
-              className={`block rounded-2xl px-4 py-3 text-sm font-medium transition ${
-                active ? "bg-white text-[var(--color-rose)] shadow-lg" : "hover:bg-white/15"
-              }`}
-            >
-              {it.label}
-            </Link>
-          );
-        })}
-      </nav>
-    </aside>
+    <>
+      <button
+        type="button"
+        className="fixed left-4 top-4 z-40 inline-flex items-center gap-2 rounded-full border border-white/40 bg-[var(--color-rose)]/90 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f0658333] backdrop-blur transition hover:bg-[var(--color-rose)] lg:hidden"
+        onClick={() => setOpen(true)}
+        aria-expanded={open}
+        aria-controls="admin-sidebar"
+      >
+        ☰ เมนูจัดการร้าน
+      </button>
+
+      <div
+        className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-300 lg:hidden ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={() => setOpen(false)}
+      />
+
+      <aside
+        id="admin-sidebar"
+        className={`fixed inset-y-0 left-0 z-50 w-72 origin-left transform bg-gradient-to-b from-[#f06583] via-[#f78da7] to-[#f6c34a] text-white shadow-[12px_0_40px_-16px_#f0658390] transition-transform duration-300 ease-in-out lg:static lg:block lg:h-auto lg:w-72 lg:translate-x-0 ${
+          open ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
+        }`}
+      >
+        <div className="flex h-16 items-center justify-between px-6 text-lg font-semibold tracking-wide">
+          <span className="flex items-center gap-2">
+            <span className="text-2xl">🍰</span>
+            Sweet Cravings
+          </span>
+          <button
+            type="button"
+            className="rounded-full border border-white/30 px-2 py-1 text-xs text-white/80 transition hover:border-white hover:text-white lg:hidden"
+            onClick={() => setOpen(false)}
+          >
+            ปิด
+          </button>
+        </div>
+
+        <div className="px-6 pb-6">
+          <div className="rounded-2xl bg-white/15 p-4 text-xs text-white/80 shadow-inner">
+            <p className="font-semibold text-white">สวัสดีผู้ดูแลร้าน!</p>
+            <p className="mt-1 leading-relaxed">
+              จัดการสินค้า ติดตามคำสั่งซื้อ และปรับโปรโมชั่นได้จากศูนย์ควบคุมนี้
+            </p>
+          </div>
+        </div>
+
+        <nav className="space-y-2 px-4 pb-8">{nav}</nav>
+
+        <div className="mt-auto space-y-3 px-6 pb-10 text-xs text-white/70">
+          <div className="rounded-2xl border border-white/20 bg-white/10 p-3 shadow-inner">
+            <p className="font-semibold text-white">เคล็ดลับวันนี้</p>
+            <p className="mt-1 leading-relaxed">
+              ใช้ส่วนลดช่วงเทศกาลเพื่อดึงลูกค้าใหม่ๆ และกระตุ้นยอดซื้อซ้ำ
+            </p>
+          </div>
+          <a
+            href="/"
+            className="inline-flex w-full items-center justify-center rounded-full bg-white/20 px-4 py-2 font-semibold text-white transition hover:bg-white/30"
+          >
+            ↩︎ กลับหน้าร้าน
+          </a>
+        </div>
+      </aside>
+    </>
   );
 }

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -1,4 +1,3 @@
-// components/admin/AdminSidebar.jsx
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -13,20 +12,25 @@ const items = [
 export default function AdminSidebar() {
   const path = usePathname();
   return (
-    <aside className="w-56 shrink-0 border-r h-[calc(100vh-0px)] sticky top-0">
-      <div className="h-14 flex items-center px-4 border-b font-bold">Admin</div>
-      <nav className="p-2 space-y-1">
-        {items.map((it) => (
-          <Link
-            key={it.href}
-            href={it.href}
-            className={`block px-3 py-2 rounded hover:bg-gray-100 ${
-              path === it.href ? "bg-gray-200 font-medium" : ""
-            }`}
-          >
-            {it.label}
-          </Link>
-        ))}
+    <aside className="w-64 shrink-0 bg-gradient-to-b from-[#f06583] to-[#f78da7] text-white shadow-2xl">
+      <div className="h-16 flex items-center px-6 text-lg font-semibold tracking-wide">
+        🍰 Admin Suite
+      </div>
+      <nav className="px-4 pb-6 space-y-2">
+        {items.map((it) => {
+          const active = path === it.href;
+          return (
+            <Link
+              key={it.href}
+              href={it.href}
+              className={`block rounded-2xl px-4 py-3 text-sm font-medium transition ${
+                active ? "bg-white text-[var(--color-rose)] shadow-lg" : "hover:bg-white/15"
+              }`}
+            >
+              {it.label}
+            </Link>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -23,11 +23,15 @@ export const authOptions = {
   ],
   callbacks: {
     async jwt({ token, user }) {
-      if (user) token.role = user.role || "user";
+      if (user) {
+        token.role = user.role || "user";
+        token.id = user.id;
+      }
       return token;
     },
     async session({ session, token }) {
       session.user.role = token.role;
+      session.user.id = token.id || token.sub;
       return session;
     },
   },

--- a/lib/paymentConfig.js
+++ b/lib/paymentConfig.js
@@ -1,0 +1,21 @@
+const FALLBACK_PROMPTPAY_ID = "0812345678";
+const FALLBACK_BANK = {
+  name: "บจก. Sweet Cravings",
+  number: "123-4-567890",
+  bank: "ธนาคารตัวอย่าง",
+};
+
+export function getPaymentConfig() {
+  const promptpayId =
+    (process.env.PROMPTPAY_ID || process.env.NEXT_PUBLIC_PROMPTPAY_ID || "").trim() || FALLBACK_PROMPTPAY_ID;
+
+  return {
+    promptpayId,
+    bankAccount: {
+      name: process.env.BANK_ACCOUNT_NAME?.trim() || FALLBACK_BANK.name,
+      number: process.env.BANK_ACCOUNT_NUMBER?.trim() || FALLBACK_BANK.number,
+      bank: process.env.BANK_ACCOUNT_BANK?.trim() || FALLBACK_BANK.bank,
+      promptpayId,
+    },
+  };
+}

--- a/lib/serializeOrder.js
+++ b/lib/serializeOrder.js
@@ -1,0 +1,59 @@
+export function serializeOrder(order, { includeSlip = false } = {}) {
+  if (!order) return null;
+  const plain = typeof order.toObject === "function" ? order.toObject() : order;
+
+  const safeDate = (value) => {
+    if (!value) return null;
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  };
+
+  const normalizeId = (value) => {
+    if (!value) return null;
+    if (typeof value === "string") return value;
+    if (typeof value === "number") return String(value);
+    if (typeof value.toString === "function") return value.toString();
+    return null;
+  };
+
+  const items = Array.isArray(plain.items)
+    ? plain.items.map((item) => ({
+        ...item,
+        _id: normalizeId(item?._id),
+        productId: normalizeId(item?.productId),
+      }))
+    : [];
+
+  const payment = plain.payment || {};
+
+  const sanitized = {
+    ...plain,
+    _id: normalizeId(plain._id),
+    id: normalizeId(plain._id),
+    userId: normalizeId(plain.userId),
+    createdAt: safeDate(plain.createdAt),
+    updatedAt: safeDate(plain.updatedAt),
+    items,
+    payment: {
+      method: payment.method || "promptpay",
+      status: payment.status || "pending",
+      ref: payment.ref || "",
+      amountPaid:
+        typeof payment.amountPaid === "number" ? payment.amountPaid : null,
+      confirmedAt: safeDate(payment.confirmedAt),
+      slip: includeSlip ? payment.slip || "" : undefined,
+      slipFilename: includeSlip ? payment.slipFilename || "" : undefined,
+    },
+  };
+
+  if (!includeSlip) {
+    delete sanitized.payment.slip;
+    delete sanitized.payment.slipFilename;
+  }
+
+  if ("__v" in sanitized) {
+    delete sanitized.__v;
+  }
+
+  return sanitized;
+}

--- a/models/Order.js
+++ b/models/Order.js
@@ -43,9 +43,13 @@ const OrderSchema = new Schema(
 
     // การชำระเงิน
     payment: {
-      method: { type: String, enum: ["stripe", "promptpay"], default: "promptpay" },
+      method: { type: String, enum: ["promptpay", "bank"], default: "promptpay" },
       status: { type: String, enum: ["pending", "paid", "failed"], default: "pending" },
       ref: String,
+      amountPaid: Number,
+      slip: String,
+      slipFilename: String,
+      confirmedAt: Date,
     },
 
     // สถานะคำสั่งซื้อ

--- a/models/Order.js
+++ b/models/Order.js
@@ -1,5 +1,7 @@
 import { Schema, models, model } from "mongoose";
 
+const PAYMENT_METHODS = ["promptpay", "bank"];
+
 const OrderSchema = new Schema(
   {
     userId: { type: Schema.Types.ObjectId, ref: "User" },
@@ -43,7 +45,7 @@ const OrderSchema = new Schema(
 
     // การชำระเงิน
     payment: {
-      method: { type: String, enum: ["promptpay", "bank"], default: "promptpay" },
+      method: { type: String, enum: PAYMENT_METHODS, default: "promptpay" },
       status: { type: String, enum: ["pending", "paid", "failed"], default: "pending" },
       ref: String,
       amountPaid: Number,
@@ -57,5 +59,16 @@ const OrderSchema = new Schema(
   },
   { timestamps: true }
 );
+
+if (models.Order) {
+  const methodPath = models.Order.schema?.path("payment.method");
+  const hasAllMethods = Array.isArray(methodPath?.enumValues)
+    ? PAYMENT_METHODS.every((value) => methodPath.enumValues.includes(value))
+    : false;
+
+  if (!hasAllMethods) {
+    delete models.Order;
+  }
+}
 
 export const Order = models.Order || model("Order", OrderSchema);


### PR DESCRIPTION
## Summary
- add bank-transfer support to checkout with method selection, transfer amount capture, and slip upload guidance on the payment screen
- verify declared transfer amounts on confirmation, persist slip metadata and paid totals, and expose bank account data for non-QR payments
- extend the order schema and admin order creation to record paid amounts alongside the new payment methods

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc6d524f4832d89ccee24ce3ab589