### PR TITLE
feat(admin): manage users with role and ban controls

### DIFF
--- a/app/(site)/about/page.jsx
+++ b/app/(site)/about/page.jsx
@@ -55,12 +55,15 @@ const milestones = [
 export default function AboutPage() {
   return (
     <div className="relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-[#fff0e1] via-[#fff8ef] to-white" aria-hidden />
+      <div
+        className="absolute inset-0 bg-gradient-to-b from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.92)] to-[var(--color-burgundy)]"
+        aria-hidden
+      />
 
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 pt-16 pb-20 space-y-12">
         <div className="grid gap-12 lg:grid-cols-[3fr_2fr] items-start">
           <div className="space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-1 text-sm font-semibold text-[var(--color-rose-dark)] shadow">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy)]/70 px-4 py-1 text-sm font-semibold text-[var(--color-rose)] shadow-lg shadow-black/40">
               Bao Lamphun Story
             </span>
             <h1 className="text-4xl sm:text-5xl font-extrabold leading-tight text-[var(--color-choco)]">
@@ -73,13 +76,13 @@ export default function AboutPage() {
               ร้านของเราตั้งอยู่ที่อำเภอเมือง จังหวัดลำพูน 51000 พร้อมต้อนรับและจัดส่งความอร่อยถึงหน้าบ้านคุณ
             </p>
             <div className="grid gap-6 sm:grid-cols-2">
-              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.2)]">
+              <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
                 <h2 className="text-xl font-semibold text-[var(--color-choco)]">ปรัชญาของเรา</h2>
                 <p className="mt-3 text-sm text-[var(--color-choco)]/70">
                   นึ่งด้วยหัวใจ เลือกเนื้อหมูและกุ้งสดใหม่ และรักษามาตรฐานความสะอาดในทุกขั้นตอน
                 </p>
               </div>
-              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.2)]">
+              <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
                 <h2 className="text-xl font-semibold text-[var(--color-choco)]">บริการของเรา</h2>
                 <ul className="mt-3 space-y-2 text-sm text-[var(--color-choco)]/70 list-disc list-inside">
                   <li>ซาลาเปาและขนมจีบประจำวัน พร้อมไส้ตามฤดูกาล</li>
@@ -91,9 +94,9 @@ export default function AboutPage() {
           </div>
 
           <div className="relative flex justify-center">
-            <div className="relative w-full max-w-sm rounded-[48%] bg-gradient-to-br from-white via-[#fff4e6] to-[#ffe8d2] p-10 shadow-2xl shadow-[rgba(240,200,105,0.25)]">
-              <div className="absolute -top-6 right-0 h-20 w-20 rounded-full bg-[#fbd8a4]/70 blur-2xl" />
-              <div className="absolute -bottom-8 left-6 h-24 w-24 rounded-full bg-[#f5be9a]/70 blur-2xl" />
+            <div className="relative w-full max-w-sm rounded-[48%] border border-[var(--color-rose)]/30 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.85)] to-[var(--color-burgundy)] p-10 shadow-2xl shadow-black/50">
+              <div className="absolute -top-6 right-0 h-20 w-20 rounded-full bg-[var(--color-rose)]/25 blur-2xl" />
+              <div className="absolute -bottom-8 left-6 h-24 w-24 rounded-full bg-[var(--color-gold)]/15 blur-2xl" />
               <div className="space-y-4 text-center">
                 <p className="text-sm font-semibold tracking-[0.2em] text-[var(--color-rose)] uppercase">
                   Since 2014
@@ -108,14 +111,14 @@ export default function AboutPage() {
         </div>
       </section>
 
-      <section className="relative bg-white/80">
+      <section className="relative bg-[rgba(58,16,16,0.65)]">
         <div className="max-w-screen-xl mx-auto px-6 lg:px-10 py-16">
           <h2 className="text-3xl font-bold text-[var(--color-choco)]">สิ่งที่เราภูมิใจ</h2>
           <div className="mt-10 grid gap-8 md:grid-cols-3">
             {highlights.map((item) => (
               <div
                 key={item.title}
-                className="rounded-3xl bg-white p-8 shadow-md shadow-[rgba(240,200,105,0.08)] flex flex-col gap-4"
+                className="flex flex-col gap-4 rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/65 p-8 shadow-2xl shadow-black/45 backdrop-blur"
               >
                 <span className="text-3xl">{item.icon}</span>
                 <h3 className="text-xl font-semibold text-[var(--color-choco)]">{item.title}</h3>
@@ -127,7 +130,7 @@ export default function AboutPage() {
       </section>
 
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 py-16">
-        <div className="rounded-3xl bg-white/90 p-10 shadow-xl shadow-[rgba(240,200,105,0.08)]">
+        <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-10 shadow-2xl shadow-black/45 backdrop-blur">
           <h2 className="text-3xl font-bold text-[var(--color-choco)]">เส้นทางของเรา</h2>
           <div className="mt-10 grid gap-8 md:grid-cols-2">
             {milestones.map((item) => (
@@ -147,7 +150,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      <section className="relative bg-gradient-to-r from-[#fff0e1] via-[#fde7b8] to-[#fbd8a4]">
+      <section className="relative bg-gradient-to-r from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.78)] to-[var(--color-burgundy)]">
         <div className="max-w-screen-xl mx-auto px-6 lg:px-10 py-16 flex flex-col gap-10 lg:flex-row lg:items-center">
           <div className="flex-1 space-y-4">
             <h2 className="text-3xl font-bold text-[var(--color-choco)]">มารู้จักทีมของเรา</h2>
@@ -161,7 +164,7 @@ export default function AboutPage() {
             </ul>
           </div>
           <div className="flex-1">
-            <div className="rounded-3xl bg-white/90 p-8 shadow-lg shadow-[rgba(240,200,105,0.2)]">
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-8 shadow-2xl shadow-black/45 backdrop-blur">
               <h3 className="text-xl font-semibold text-[var(--color-choco)]">อยากร่วมงานกับเรา?</h3>
               <p className="mt-3 text-sm text-[var(--color-choco)]/70">
                 เรากำลังมองหาพาร์ตเนอร์ด้านวัตถุดิบ เครื่องนึ่ง และทีมจัดส่งในลำพูนที่อยากเติบโตไปด้วยกัน ติดต่อเราได้ที่

--- a/app/(site)/about/page.jsx
+++ b/app/(site)/about/page.jsx
@@ -73,13 +73,13 @@ export default function AboutPage() {
               ร้านของเราตั้งอยู่ที่อำเภอเมือง จังหวัดลำพูน 51000 พร้อมต้อนรับและจัดส่งความอร่อยถึงหน้าบ้านคุณ
             </p>
             <div className="grid gap-6 sm:grid-cols-2">
-              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d20]">
+              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.2)]">
                 <h2 className="text-xl font-semibold text-[var(--color-choco)]">ปรัชญาของเรา</h2>
                 <p className="mt-3 text-sm text-[var(--color-choco)]/70">
                   นึ่งด้วยหัวใจ เลือกเนื้อหมูและกุ้งสดใหม่ และรักษามาตรฐานความสะอาดในทุกขั้นตอน
                 </p>
               </div>
-              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d20]">
+              <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.2)]">
                 <h2 className="text-xl font-semibold text-[var(--color-choco)]">บริการของเรา</h2>
                 <ul className="mt-3 space-y-2 text-sm text-[var(--color-choco)]/70 list-disc list-inside">
                   <li>ซาลาเปาและขนมจีบประจำวัน พร้อมไส้ตามฤดูกาล</li>
@@ -91,7 +91,7 @@ export default function AboutPage() {
           </div>
 
           <div className="relative flex justify-center">
-            <div className="relative w-full max-w-sm rounded-[48%] bg-gradient-to-br from-white via-[#fff4e6] to-[#ffe8d2] p-10 shadow-2xl shadow-[#f5a25d25]">
+            <div className="relative w-full max-w-sm rounded-[48%] bg-gradient-to-br from-white via-[#fff4e6] to-[#ffe8d2] p-10 shadow-2xl shadow-[rgba(240,200,105,0.25)]">
               <div className="absolute -top-6 right-0 h-20 w-20 rounded-full bg-[#fbd8a4]/70 blur-2xl" />
               <div className="absolute -bottom-8 left-6 h-24 w-24 rounded-full bg-[#f5be9a]/70 blur-2xl" />
               <div className="space-y-4 text-center">
@@ -115,7 +115,7 @@ export default function AboutPage() {
             {highlights.map((item) => (
               <div
                 key={item.title}
-                className="rounded-3xl bg-white p-8 shadow-md shadow-[#f5a25d15] flex flex-col gap-4"
+                className="rounded-3xl bg-white p-8 shadow-md shadow-[rgba(240,200,105,0.08)] flex flex-col gap-4"
               >
                 <span className="text-3xl">{item.icon}</span>
                 <h3 className="text-xl font-semibold text-[var(--color-choco)]">{item.title}</h3>
@@ -127,13 +127,13 @@ export default function AboutPage() {
       </section>
 
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 py-16">
-        <div className="rounded-3xl bg-white/90 p-10 shadow-xl shadow-[#f5a25d15]">
+        <div className="rounded-3xl bg-white/90 p-10 shadow-xl shadow-[rgba(240,200,105,0.08)]">
           <h2 className="text-3xl font-bold text-[var(--color-choco)]">เส้นทางของเรา</h2>
           <div className="mt-10 grid gap-8 md:grid-cols-2">
             {milestones.map((item) => (
               <div key={item.year} className="flex gap-6">
                 <div className="flex-shrink-0">
-                  <div className="rounded-full bg-gradient-to-br from-[#f5a25d] to-[#f3d36b] px-4 py-2 text-sm font-semibold text-white shadow">
+                  <div className="rounded-full bg-gradient-to-br from-[var(--color-rose)] to-[var(--color-gold)] px-4 py-2 text-sm font-semibold text-white shadow">
                     {item.year}
                   </div>
                 </div>
@@ -161,7 +161,7 @@ export default function AboutPage() {
             </ul>
           </div>
           <div className="flex-1">
-            <div className="rounded-3xl bg-white/90 p-8 shadow-lg shadow-[#f5a25d20]">
+            <div className="rounded-3xl bg-white/90 p-8 shadow-lg shadow-[rgba(240,200,105,0.2)]">
               <h3 className="text-xl font-semibold text-[var(--color-choco)]">อยากร่วมงานกับเรา?</h3>
               <p className="mt-3 text-sm text-[var(--color-choco)]/70">
                 เรากำลังมองหาพาร์ตเนอร์ด้านวัตถุดิบ เครื่องนึ่ง และทีมจัดส่งในลำพูนที่อยากเติบโตไปด้วยกัน ติดต่อเราได้ที่

--- a/app/(site)/cart/page.jsx
+++ b/app/(site)/cart/page.jsx
@@ -63,7 +63,7 @@ export default function CartPage() {
   }
 
   const summary = (
-    <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d22]">
+    <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.22)]">
       <div className="flex items-center justify-between text-lg font-semibold text-[var(--color-choco)]">
         <span>ยอดรวม</span>
         <span>฿{cart.subtotal}</span>
@@ -79,12 +79,12 @@ export default function CartPage() {
       <div className="mt-6 flex flex-col gap-3">
         <Link
           href="/checkout"
-          className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
         >
           ไปหน้าชำระเงิน
         </Link>
         <button
-          className="rounded-full border border-[#f4c689]/60 px-6 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[#fff5e4]"
+          className="rounded-full border border-[var(--color-rose)]/35 px-6 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[rgba(240,200,105,0.12)]"
           onClick={cart.clear}
         >
           ลบสินค้าทั้งหมด
@@ -106,7 +106,7 @@ export default function CartPage() {
   if (status === "unauthenticated") {
     return (
       <main className="flex min-h-[70vh] items-center justify-center bg-[var(--color-cream)]/40">
-        <div className="rounded-3xl bg-white/90 px-8 py-10 text-center text-[var(--color-choco)] shadow-lg shadow-[#f5a25d22]">
+        <div className="rounded-3xl bg-white/90 px-8 py-10 text-center text-[var(--color-choco)] shadow-lg shadow-[rgba(240,200,105,0.22)]">
           <p className="text-lg font-semibold">กรุณาเข้าสู่ระบบเพื่อเปิดตะกร้าสินค้า</p>
           <p className="mt-3 text-sm text-[var(--color-choco)]/70">
             ระบบกำลังพาไปยังหน้าเข้าสู่ระบบอัตโนมัติ หากไม่เปลี่ยนหน้า
@@ -126,7 +126,7 @@ export default function CartPage() {
     <main className="relative min-h-[70vh] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#fff0e1] via-[#fff8ef] to-[#fde7b8]" />
       <div className="absolute -top-24 right-8 h-64 w-64 rounded-full bg-[#f3d36b]/30 blur-3xl" />
-      <div className="absolute -bottom-20 left-0 h-72 w-72 rounded-full bg-[#f5a25d]/20 blur-3xl" />
+      <div className="absolute -bottom-20 left-0 h-72 w-72 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
         <div className="flex flex-col gap-6">
@@ -138,7 +138,7 @@ export default function CartPage() {
           </div>
 
           {cart.items.length === 0 ? (
-            <div className="rounded-3xl bg-white/80 p-10 text-center shadow-lg shadow-[#f5a25d22]">
+            <div className="rounded-3xl bg-white/80 p-10 text-center shadow-lg shadow-[rgba(240,200,105,0.22)]">
               <p className="text-lg font-medium text-[var(--color-choco)]">ตะกร้าของคุณยังว่าง</p>
               <p className="mt-2 text-sm text-[var(--color-choco)]/70">
                 ลองกลับไปเลือกเมนูโปรดดูนะคะ —
@@ -153,7 +153,7 @@ export default function CartPage() {
                 {cart.items.map((it) => (
                   <div
                     key={it.productId}
-                    className="flex flex-col gap-3 rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d1a] sm:flex-row sm:items-center sm:justify-between"
+                    className="flex flex-col gap-3 rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.1)] sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div>
                       <div className="text-lg font-semibold text-[var(--color-choco)]">{it.title}</div>
@@ -167,7 +167,7 @@ export default function CartPage() {
                         onChange={(e) =>
                           cart.setQty(it.productId, parseInt(e.target.value || "1", 10))
                         }
-                        className="h-11 w-24 rounded-full border border-[#f4c689]/60 bg-white px-4 text-center text-sm font-medium text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                        className="h-11 w-24 rounded-full border border-[var(--color-rose)]/35 bg-white px-4 text-center text-sm font-medium text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                       />
                       <button
                         className="text-sm font-medium text-[var(--color-rose-dark)] underline decoration-dotted"
@@ -181,7 +181,7 @@ export default function CartPage() {
               </div>
 
               <div className="space-y-6">
-                <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d22]">
+                <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.22)]">
                   <h2 className="text-lg font-semibold text-[var(--color-choco)]">ใช้คูปอง</h2>
                   <p className="mt-1 text-xs text-[var(--color-choco)]/70">กรอกโค้ดเพื่อรับส่วนลดพิเศษ</p>
                   <div className="mt-4 flex flex-col gap-3 sm:flex-row">
@@ -189,19 +189,19 @@ export default function CartPage() {
                       value={code}
                       onChange={(e) => setCode(e.target.value)}
                       placeholder="เช่น SWEET10"
-                      className="flex-1 rounded-full border border-[#f4c689]/60 bg-white px-5 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                      className="flex-1 rounded-full border border-[var(--color-rose)]/35 bg-white px-5 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                     />
                     <button
                       onClick={applyCoupon}
                       disabled={applying}
-                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f7c68b] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[#f5a25d33] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[rgba(240,200,105,0.33)] disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {applying ? "กำลังตรวจสอบ..." : "ใช้คูปอง"}
                     </button>
                     {cart.coupon && (
                       <button
                         onClick={() => cart.clearCoupon()}
-                        className="rounded-full border border-[#f5a25d]/20 px-5 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[#fff5e4]"
+                        className="rounded-full border border-[var(--color-rose)]/20 px-5 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[rgba(240,200,105,0.12)]"
                       >
                         ลบคูปอง
                       </button>

--- a/app/(site)/cart/page.jsx
+++ b/app/(site)/cart/page.jsx
@@ -63,13 +63,13 @@ export default function CartPage() {
   }
 
   const summary = (
-    <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.22)]">
-      <div className="flex items-center justify-between text-lg font-semibold text-[var(--color-choco)]">
+    <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 p-6 text-[var(--color-text)] shadow-lg shadow-black/40 backdrop-blur">
+      <div className="flex items-center justify-between text-lg font-semibold text-[var(--color-gold)]">
         <span>ยอดรวม</span>
         <span>฿{cart.subtotal}</span>
       </div>
       {cart.coupon?.discount ? (
-        <div className="mt-3 flex items-center justify-between text-sm text-emerald-600">
+        <div className="mt-3 flex items-center justify-between rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy-dark)]/60 px-4 py-2 text-xs text-[var(--color-gold)]/85">
           <span>
             ใช้คูปอง {cart.coupon.code} ({cart.coupon.description})
           </span>
@@ -79,12 +79,12 @@ export default function CartPage() {
       <div className="mt-6 flex flex-col gap-3">
         <Link
           href="/checkout"
-          className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
         >
           ไปหน้าชำระเงิน
         </Link>
         <button
-          className="rounded-full border border-[var(--color-rose)]/35 px-6 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[rgba(240,200,105,0.12)]"
+          className="rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/50 px-6 py-3 text-sm font-medium text-[var(--color-gold)] transition hover:bg-[var(--color-burgundy)]/60"
           onClick={cart.clear}
         >
           ลบสินค้าทั้งหมด
@@ -95,8 +95,8 @@ export default function CartPage() {
 
   if (status === "loading") {
     return (
-      <main className="flex min-h-[70vh] items-center justify-center bg-[var(--color-cream)]/40">
-        <div className="rounded-full bg-white/90 px-6 py-3 text-sm text-[var(--color-choco)] shadow">
+      <main className="flex min-h-[70vh] items-center justify-center bg-[var(--color-burgundy-dark)]/60">
+        <div className="rounded-full border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/70 px-6 py-3 text-sm text-[var(--color-gold)] shadow-inner">
           กำลังตรวจสอบสถานะการเข้าสู่ระบบ...
         </div>
       </main>
@@ -105,14 +105,14 @@ export default function CartPage() {
 
   if (status === "unauthenticated") {
     return (
-      <main className="flex min-h-[70vh] items-center justify-center bg-[var(--color-cream)]/40">
-        <div className="rounded-3xl bg-white/90 px-8 py-10 text-center text-[var(--color-choco)] shadow-lg shadow-[rgba(240,200,105,0.22)]">
-          <p className="text-lg font-semibold">กรุณาเข้าสู่ระบบเพื่อเปิดตะกร้าสินค้า</p>
-          <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+      <main className="flex min-h-[70vh] items-center justify-center bg-[var(--color-burgundy-dark)]/60">
+        <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 px-8 py-10 text-center text-[var(--color-text)] shadow-xl shadow-black/40 backdrop-blur">
+          <p className="text-lg font-semibold text-[var(--color-gold)]">กรุณาเข้าสู่ระบบเพื่อเปิดตะกร้าสินค้า</p>
+          <p className="mt-3 text-sm text-[var(--color-text)]/70">
             ระบบกำลังพาไปยังหน้าเข้าสู่ระบบอัตโนมัติ หากไม่เปลี่ยนหน้า
             <Link
               href={`/login?callbackUrl=${encodeURIComponent("/cart")}`}
-              className="ml-1 text-[var(--color-rose-dark)] underline"
+              className="ml-1 font-semibold text-[var(--color-rose)] underline"
             >
               คลิกที่นี่เพื่อเข้าสู่ระบบ
             </Link>
@@ -124,25 +124,25 @@ export default function CartPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#fff0e1] via-[#fff8ef] to-[#fde7b8]" />
-      <div className="absolute -top-24 right-8 h-64 w-64 rounded-full bg-[#f3d36b]/30 blur-3xl" />
-      <div className="absolute -bottom-20 left-0 h-72 w-72 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_60%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(135deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute -top-24 right-8 h-64 w-64 rounded-full bg-[var(--color-rose)]/25 blur-3xl" />
+      <div className="absolute -bottom-20 left-0 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/25 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
         <div className="flex flex-col gap-6">
           <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
             <div>
-              <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ตะกร้าของฉัน</h1>
-              <p className="mt-1 text-sm text-[var(--color-choco)]/70">ตรวจสอบสินค้า และใช้คูปองส่วนลดก่อนชำระเงิน</p>
+              <h1 className="text-3xl font-bold text-[var(--color-rose)]">ตะกร้าของฉัน</h1>
+              <p className="mt-1 text-sm text-[var(--color-text)]/70">ตรวจสอบสินค้า และใช้คูปองส่วนลดก่อนชำระเงิน</p>
             </div>
           </div>
 
           {cart.items.length === 0 ? (
-            <div className="rounded-3xl bg-white/80 p-10 text-center shadow-lg shadow-[rgba(240,200,105,0.22)]">
-              <p className="text-lg font-medium text-[var(--color-choco)]">ตะกร้าของคุณยังว่าง</p>
-              <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+            <div className="rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 p-10 text-center text-[var(--color-text)] shadow-lg shadow-black/40 backdrop-blur">
+              <p className="text-lg font-medium text-[var(--color-gold)]">ตะกร้าของคุณยังว่าง</p>
+              <p className="mt-2 text-sm text-[var(--color-text)]/70">
                 ลองกลับไปเลือกเมนูโปรดดูนะคะ —
-                <Link href="/" className="ml-1 underline">
+                <Link href="/" className="ml-1 font-semibold text-[var(--color-rose)] underline">
                   หน้าร้านหลัก
                 </Link>
               </p>
@@ -153,13 +153,13 @@ export default function CartPage() {
                 {cart.items.map((it) => (
                   <div
                     key={it.productId}
-                    className="flex flex-col gap-3 rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.1)] sm:flex-row sm:items-center sm:justify-between"
+                    className="flex flex-col gap-3 rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 p-6 text-[var(--color-text)] shadow-lg shadow-black/30 backdrop-blur sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div>
-                      <div className="text-lg font-semibold text-[var(--color-choco)]">{it.title}</div>
-                      <div className="text-sm text-[var(--color-choco)]/70">฿{it.price} ต่อชิ้น</div>
+                      <div className="text-lg font-semibold text-[var(--color-gold)]">{it.title}</div>
+                      <div className="text-sm text-[var(--color-text)]/70">฿{it.price} ต่อชิ้น</div>
                     </div>
-                    <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
                       <input
                         type="number"
                         min={1}
@@ -167,10 +167,10 @@ export default function CartPage() {
                         onChange={(e) =>
                           cart.setQty(it.productId, parseInt(e.target.value || "1", 10))
                         }
-                        className="h-11 w-24 rounded-full border border-[var(--color-rose)]/35 bg-white px-4 text-center text-sm font-medium text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                        className="h-11 w-24 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 text-center text-sm font-medium text-[var(--color-gold)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                       />
                       <button
-                        className="text-sm font-medium text-[var(--color-rose-dark)] underline decoration-dotted"
+                        className="text-sm font-medium text-[var(--color-rose)] underline decoration-dotted"
                         onClick={() => cart.remove(it.productId)}
                       >
                         ลบออก
@@ -181,27 +181,27 @@ export default function CartPage() {
               </div>
 
               <div className="space-y-6">
-                <div className="rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.22)]">
-                  <h2 className="text-lg font-semibold text-[var(--color-choco)]">ใช้คูปอง</h2>
-                  <p className="mt-1 text-xs text-[var(--color-choco)]/70">กรอกโค้ดเพื่อรับส่วนลดพิเศษ</p>
+                <div className="rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 p-6 text-[var(--color-text)] shadow-lg shadow-black/40 backdrop-blur">
+                  <h2 className="text-lg font-semibold text-[var(--color-gold)]">ใช้คูปอง</h2>
+                  <p className="mt-1 text-xs text-[var(--color-text)]/70">กรอกโค้ดเพื่อรับส่วนลดพิเศษ</p>
                   <div className="mt-4 flex flex-col gap-3 sm:flex-row">
                     <input
                       value={code}
                       onChange={(e) => setCode(e.target.value)}
                       placeholder="เช่น SWEET10"
-                      className="flex-1 rounded-full border border-[var(--color-rose)]/35 bg-white px-5 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                      className="flex-1 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-5 py-3 text-sm text-[var(--color-gold)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                     />
                     <button
                       onClick={applyCoupon}
                       disabled={applying}
-                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md shadow-[rgba(240,200,105,0.33)] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {applying ? "กำลังตรวจสอบ..." : "ใช้คูปอง"}
                     </button>
                     {cart.coupon && (
                       <button
                         onClick={() => cart.clearCoupon()}
-                        className="rounded-full border border-[var(--color-rose)]/20 px-5 py-3 text-sm font-medium text-[var(--color-choco)] hover:bg-[rgba(240,200,105,0.12)]"
+                        className="rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/50 px-5 py-3 text-sm font-medium text-[var(--color-gold)] transition hover:bg-[var(--color-burgundy)]/60"
                       >
                         ลบคูปอง
                       </button>
@@ -209,7 +209,7 @@ export default function CartPage() {
                   </div>
                   {err && <div className="mt-3 text-sm text-rose-600">{err}</div>}
                   {cart.coupon && (
-                    <div className="mt-3 rounded-2xl bg-[#ecfdf5] px-4 py-3 text-sm text-emerald-700">
+                    <div className="mt-3 rounded-2xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-sm text-[var(--color-gold)]/85">
                       ใช้คูปอง {cart.coupon.code} — {cart.coupon.description} (คำนวณอีกครั้งตอนชำระเงิน)
                     </div>
                   )}

--- a/app/(site)/checkout/page.jsx
+++ b/app/(site)/checkout/page.jsx
@@ -237,9 +237,9 @@ export default function CheckoutPage() {
 
   return (
     <main className="relative min-h-screen overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#fff0e1] via-[#fff8ef] to-[#fde7b8]" />
-      <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
-      <div className="absolute -bottom-28 right-10 h-72 w-72 rounded-full bg-[#f3d36b]/25 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.9)] to-[var(--color-burgundy)]" />
+      <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/18 blur-3xl" />
+      <div className="absolute -bottom-28 right-10 h-72 w-72 rounded-full bg-[var(--color-gold)]/18 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
         <div className="max-w-2xl">
@@ -251,7 +251,7 @@ export default function CheckoutPage() {
         </div>
 
         <div className="mt-10 grid gap-8 lg:grid-cols-[1.5fr_1fr]">
-          <section className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[rgba(240,200,105,0.19)] space-y-6">
+          <section className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-8 shadow-2xl shadow-black/45 backdrop-blur space-y-6">
             <div>
               <h2 className="text-xl font-semibold text-[var(--color-choco)]">ข้อมูลผู้รับและที่อยู่</h2>
               <p className="mt-1 text-xs text-[var(--color-choco)]/70">ช่องที่มีเครื่องหมาย * จำเป็นต้องกรอก</p>
@@ -280,7 +280,7 @@ export default function CheckoutPage() {
                       : "หมายเหตุถึงร้าน"}
                   </label>
                   <input
-                    className={`w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30 ${
+                    className={`w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40 ${
                       REQUIRED_FIELDS.includes(key) && !form[key] ? "border-rose-300" : ""
                     }`}
                     value={form[key]}
@@ -309,12 +309,12 @@ export default function CheckoutPage() {
                       disabled={updatingMethod && paymentMethod !== option.value}
                       className={`rounded-2xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40 ${
                         active
-                          ? "border-[var(--color-rose)] bg-[rgba(240,200,105,0.12)] text-[var(--color-rose-dark)] shadow"
-                          : "border-[var(--color-rose)]/35 bg-white text-[var(--color-choco)]/80"
+                          ? "border-[var(--color-rose)] bg-[rgba(240,200,105,0.16)] text-[var(--color-rose)] shadow-lg shadow-black/40"
+                          : "border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/55 text-[var(--color-text)]/80"
                       } ${updatingMethod ? "cursor-wait" : ""}`}
                     >
                       <div className="text-sm font-semibold">{option.label}</div>
-                      <div className="mt-1 text-xs text-[var(--color-choco)]/70">{option.description}</div>
+                      <div className="mt-1 text-xs text-[var(--color-text)]/70">{option.description}</div>
                     </button>
                   );
                 })}
@@ -330,7 +330,7 @@ export default function CheckoutPage() {
                 disabled={creating || cart.items.length === 0 || Boolean(order)}
                 className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                   creating || cart.items.length === 0 || order
-                    ? "bg-[#f2c8a5] cursor-not-allowed"
+                    ? "bg-[var(--color-burgundy-dark)]/40 cursor-not-allowed"
                     : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] hover:shadow-xl"
                 }`}
               >
@@ -344,11 +344,11 @@ export default function CheckoutPage() {
               </button>
             </div>
 
-            {err && <div className="text-sm text-rose-600">{err}</div>}
+            {err && <div className="text-sm text-[var(--color-rose)]">{err}</div>}
           </section>
 
           <section className="space-y-6">
-            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[rgba(240,200,105,0.1)]">
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">สรุปรายการ</h2>
               <div className="mt-4 space-y-3 text-sm">
                 {currentTotals.items.map((it) => (
@@ -366,7 +366,7 @@ export default function CheckoutPage() {
                   <span>฿{fmt(currentTotals.subtotal)}</span>
                 </div>
                 {currentTotals.discount ? (
-                  <div className="flex justify-between text-emerald-600">
+                  <div className="flex justify-between text-[var(--color-gold)]">
                     <span>
                       คูปอง {currentTotals.coupon?.code}
                       {currentTotals.coupon?.description ? ` (${currentTotals.coupon.description})` : ""}
@@ -381,11 +381,11 @@ export default function CheckoutPage() {
               </div>
             </div>
 
-            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[rgba(240,200,105,0.1)] space-y-4">
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur space-y-4">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">ยืนยันการโอน</h2>
               {order ? (
                 <div className="space-y-4">
-                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/35 bg-[rgba(240,200,105,0.12)] px-4 py-3 text-sm text-[var(--color-gold)]">
                     สร้างคำสั่งซื้อ #{order.orderId} แล้ว กรุณาชำระเงินและแนบสลิปเพื่อยืนยัน ระบบจะตรวจสอบยอดที่ชำระให้อัตโนมัติ
                   </div>
                   {order.promptpay ? (
@@ -395,7 +395,7 @@ export default function CheckoutPage() {
                       title="สแกนเพื่อชำระเงิน"
                     />
                   ) : paymentMethod === "bank" && order.bankAccount ? (
-                    <div className="space-y-3 rounded-2xl border border-[#f4c689]/50 bg-[rgba(240,200,105,0.12)] p-4 text-sm text-[var(--color-choco)]">
+                    <div className="space-y-3 rounded-2xl border border-[var(--color-rose)]/35 bg-[rgba(240,200,105,0.12)] p-4 text-sm text-[var(--color-choco)]">
                       <div className="font-semibold text-[var(--color-rose-dark)]">รายละเอียดบัญชีสำหรับโอน</div>
                       <div>ธนาคาร: {order.bankAccount.bank}</div>
                       <div>เลขบัญชี: {order.bankAccount.number}</div>
@@ -417,13 +417,13 @@ export default function CheckoutPage() {
                         type="text"
                         value={transferAmount}
                         onChange={(e) => setTransferAmount(e.target.value)}
-                        className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                        className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-2 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                         placeholder={`ยอดที่ต้องชำระ ฿${fmt(order.orderPreview.total)}`}
                       />
                       <p className="text-xs text-[var(--color-choco)]/60">ยอดที่ต้องชำระทั้งหมด ฿{fmt(order.orderPreview.total)}</p>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                    <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/40 px-4 py-3 text-sm text-[var(--color-text)]/75">
                       ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                     </div>
                   )}
@@ -434,7 +434,7 @@ export default function CheckoutPage() {
                       type="text"
                       value={reference}
                       onChange={(e) => setReference(e.target.value)}
-                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-2 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                       placeholder="เช่น เลขที่รายการ หรือเลขอ้างอิงจากแอปธนาคาร"
                     />
                   </div>
@@ -454,7 +454,7 @@ export default function CheckoutPage() {
                     disabled={confirming || updatingMethod || !slipData || (needsPayment && !transferAmount)}
                     className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                       confirming || updatingMethod || !slipData || (needsPayment && !transferAmount)
-                        ? "bg-[#f2c8a5] cursor-not-allowed"
+                        ? "bg-[var(--color-burgundy-dark)]/40 cursor-not-allowed"
                         : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
                     }`}
                   >
@@ -466,7 +466,7 @@ export default function CheckoutPage() {
                   กดปุ่ม "สร้างคำสั่งซื้อ" เพื่อสร้างคำสั่งซื้อและรับรายละเอียดการชำระเงิน
                 </div>
               )}
-              {err && order && <div className="text-sm text-rose-600">{err}</div>}
+              {err && order && <div className="text-sm text-[var(--color-rose)]">{err}</div>}
             </div>
           </section>
         </div>

--- a/app/(site)/checkout/page.jsx
+++ b/app/(site)/checkout/page.jsx
@@ -238,7 +238,7 @@ export default function CheckoutPage() {
   return (
     <main className="relative min-h-screen overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#fff0e1] via-[#fff8ef] to-[#fde7b8]" />
-      <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[#f5a25d]/20 blur-3xl" />
+      <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-28 right-10 h-72 w-72 rounded-full bg-[#f3d36b]/25 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
@@ -251,7 +251,7 @@ export default function CheckoutPage() {
         </div>
 
         <div className="mt-10 grid gap-8 lg:grid-cols-[1.5fr_1fr]">
-          <section className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[#f5a25d1f] space-y-6">
+          <section className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[rgba(240,200,105,0.19)] space-y-6">
             <div>
               <h2 className="text-xl font-semibold text-[var(--color-choco)]">ข้อมูลผู้รับและที่อยู่</h2>
               <p className="mt-1 text-xs text-[var(--color-choco)]/70">ช่องที่มีเครื่องหมาย * จำเป็นต้องกรอก</p>
@@ -280,7 +280,7 @@ export default function CheckoutPage() {
                       : "หมายเหตุถึงร้าน"}
                   </label>
                   <input
-                    className={`w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30 ${
+                    className={`w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30 ${
                       REQUIRED_FIELDS.includes(key) && !form[key] ? "border-rose-300" : ""
                     }`}
                     value={form[key]}
@@ -290,7 +290,7 @@ export default function CheckoutPage() {
               ))}
             </div>
 
-            <div className="space-y-4 pt-4 border-t border-[#f4c689]/40">
+            <div className="space-y-4 pt-4 border-t border-[var(--color-rose)]/30">
               <div>
                 <h3 className="text-lg font-semibold text-[var(--color-choco)]">เลือกวิธีการชำระเงิน</h3>
                 <p className="mt-1 text-xs text-[var(--color-choco)]/70">
@@ -307,10 +307,10 @@ export default function CheckoutPage() {
                       type="button"
                       onClick={() => handleSelectMethod(option.value)}
                       disabled={updatingMethod && paymentMethod !== option.value}
-                      className={`rounded-2xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/40 ${
+                      className={`rounded-2xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40 ${
                         active
-                          ? "border-[#f5a25d] bg-[#fff6ed] text-[var(--color-rose-dark)] shadow"
-                          : "border-[#f4c689]/60 bg-white text-[var(--color-choco)]/80"
+                          ? "border-[var(--color-rose)] bg-[rgba(240,200,105,0.12)] text-[var(--color-rose-dark)] shadow"
+                          : "border-[var(--color-rose)]/35 bg-white text-[var(--color-choco)]/80"
                       } ${updatingMethod ? "cursor-wait" : ""}`}
                     >
                       <div className="text-sm font-semibold">{option.label}</div>
@@ -328,10 +328,10 @@ export default function CheckoutPage() {
               <button
                 onClick={placeOrder}
                 disabled={creating || cart.items.length === 0 || Boolean(order)}
-                className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition ${
+                className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                   creating || cart.items.length === 0 || order
                     ? "bg-[#f2c8a5] cursor-not-allowed"
-                    : "bg-gradient-to-r from-[#f5a25d] to-[#f7c68b] hover:shadow-xl"
+                    : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] hover:shadow-xl"
                 }`}
               >
                 {order
@@ -348,7 +348,7 @@ export default function CheckoutPage() {
           </section>
 
           <section className="space-y-6">
-            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[#f5a25d1a]">
+            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[rgba(240,200,105,0.1)]">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">สรุปรายการ</h2>
               <div className="mt-4 space-y-3 text-sm">
                 {currentTotals.items.map((it) => (
@@ -360,7 +360,7 @@ export default function CheckoutPage() {
                   </div>
                 ))}
               </div>
-              <div className="mt-4 space-y-2 border-t border-[#f4c689]/40 pt-4 text-sm">
+              <div className="mt-4 space-y-2 border-t border-[var(--color-rose)]/30 pt-4 text-sm">
                 <div className="flex justify-between text-[var(--color-choco)]/80">
                   <span>รวม</span>
                   <span>฿{fmt(currentTotals.subtotal)}</span>
@@ -381,7 +381,7 @@ export default function CheckoutPage() {
               </div>
             </div>
 
-            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[#f5a25d1a] space-y-4">
+            <div className="rounded-3xl bg-white/90 p-6 shadow-xl shadow-[rgba(240,200,105,0.1)] space-y-4">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">ยืนยันการโอน</h2>
               {order ? (
                 <div className="space-y-4">
@@ -395,7 +395,7 @@ export default function CheckoutPage() {
                       title="สแกนเพื่อชำระเงิน"
                     />
                   ) : paymentMethod === "bank" && order.bankAccount ? (
-                    <div className="space-y-3 rounded-2xl border border-[#f4c689]/50 bg-[#fff6ed] p-4 text-sm text-[var(--color-choco)]">
+                    <div className="space-y-3 rounded-2xl border border-[#f4c689]/50 bg-[rgba(240,200,105,0.12)] p-4 text-sm text-[var(--color-choco)]">
                       <div className="font-semibold text-[var(--color-rose-dark)]">รายละเอียดบัญชีสำหรับโอน</div>
                       <div>ธนาคาร: {order.bankAccount.bank}</div>
                       <div>เลขบัญชี: {order.bankAccount.number}</div>
@@ -417,13 +417,13 @@ export default function CheckoutPage() {
                         type="text"
                         value={transferAmount}
                         onChange={(e) => setTransferAmount(e.target.value)}
-                        className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                        className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                         placeholder={`ยอดที่ต้องชำระ ฿${fmt(order.orderPreview.total)}`}
                       />
                       <p className="text-xs text-[var(--color-choco)]/60">ยอดที่ต้องชำระทั้งหมด ฿{fmt(order.orderPreview.total)}</p>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-[#f4c689]/40 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                    <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
                       ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                     </div>
                   )}
@@ -434,7 +434,7 @@ export default function CheckoutPage() {
                       type="text"
                       value={reference}
                       onChange={(e) => setReference(e.target.value)}
-                      className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                       placeholder="เช่น เลขที่รายการ หรือเลขอ้างอิงจากแอปธนาคาร"
                     />
                   </div>
@@ -452,10 +452,10 @@ export default function CheckoutPage() {
                   <button
                     onClick={confirmPayment}
                     disabled={confirming || updatingMethod || !slipData || (needsPayment && !transferAmount)}
-                    className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition ${
+                    className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                       confirming || updatingMethod || !slipData || (needsPayment && !transferAmount)
                         ? "bg-[#f2c8a5] cursor-not-allowed"
-                        : "bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] hover:shadow-xl"
+                        : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
                     }`}
                   >
                     {confirming ? "กำลังยืนยัน..." : updatingMethod ? "กำลังอัปเดตวิธีชำระเงิน..." : "ยืนยันการชำระเงิน"}

--- a/app/(site)/hook/page.jsx
+++ b/app/(site)/hook/page.jsx
@@ -5,22 +5,22 @@ export default function HookPage({ searchParams }) {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#ecfdf5] via-[#fff] to-[#fff4e6]" />
-      <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#f3d36b]/25 blur-3xl" />
-      <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.88)] to-[var(--color-burgundy)]" />
+      <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[var(--color-gold)]/15 blur-3xl" />
 
       <div className="relative flex items-center justify-center px-6 py-20">
-        <div className="max-w-lg w-full rounded-3xl bg-white/95 p-10 text-center shadow-2xl shadow-[rgba(240,200,105,0.2)]">
+        <div className="w-full max-w-lg rounded-3xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/70 p-10 text-center shadow-2xl shadow-black/45 backdrop-blur">
           <div className="space-y-3">
-            <span className="inline-flex items-center gap-2 rounded-full bg-[#ecfdf5] px-4 py-2 text-xs font-semibold text-emerald-600">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/40 px-4 py-2 text-xs font-semibold text-[var(--color-rose)]">
               ✅ รับคำสั่งซื้อแล้ว
             </span>
-            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ขอบคุณที่สั่ง Sweet Cravings</h1>
-            <p className="text-sm text-[var(--color-choco)]/70">
+            <h1 className="text-3xl font-bold text-[var(--color-rose)]">ขอบคุณที่สั่ง Sweet Cravings</h1>
+            <p className="text-sm text-[var(--color-text)]/75">
               เราได้รับสลิปและรายละเอียดการชำระเงินแล้ว ทีมงานจะตรวจสอบและยืนยันสถานะให้โดยเร็วที่สุด
             </p>
             {orderId ? (
-              <p className="text-xs font-medium text-[var(--color-choco)]/60">รหัสคำสั่งซื้อของคุณ: {orderId}</p>
+              <p className="text-xs font-medium text-[var(--color-text)]/60">รหัสคำสั่งซื้อของคุณ: {orderId}</p>
             ) : null}
           </div>
 

--- a/app/(site)/hook/page.jsx
+++ b/app/(site)/hook/page.jsx
@@ -7,10 +7,10 @@ export default function HookPage({ searchParams }) {
     <main className="relative min-h-[70vh] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#ecfdf5] via-[#fff] to-[#fff4e6]" />
       <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#f3d36b]/25 blur-3xl" />
-      <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[#f5a25d]/15 blur-3xl" />
+      <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
 
       <div className="relative flex items-center justify-center px-6 py-20">
-        <div className="max-w-lg w-full rounded-3xl bg-white/95 p-10 text-center shadow-2xl shadow-[#f5a25d20]">
+        <div className="max-w-lg w-full rounded-3xl bg-white/95 p-10 text-center shadow-2xl shadow-[rgba(240,200,105,0.2)]">
           <div className="space-y-3">
             <span className="inline-flex items-center gap-2 rounded-full bg-[#ecfdf5] px-4 py-2 text-xs font-semibold text-emerald-600">
               ✅ รับคำสั่งซื้อแล้ว
@@ -26,7 +26,7 @@ export default function HookPage({ searchParams }) {
 
           <Link
             href="/"
-            className="mt-8 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:shadow-xl"
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:shadow-xl"
           >
             กลับสู่หน้าหลัก
           </Link>

--- a/app/(site)/login/page.js
+++ b/app/(site)/login/page.js
@@ -35,15 +35,15 @@ function LoginContent() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe1ef] via-[#fff7f0] to-[#ffe6d4]" />
-      <div className="absolute -top-24 right-20 h-64 w-64 rounded-full bg-[#f5a25d]/20 blur-3xl" />
-      <div className="absolute -bottom-28 left-12 h-72 w-72 rounded-full bg-[#f3d36b]/25 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[#3a1010]" />
+      <div className="absolute -top-24 right-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute -bottom-28 left-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
       <div className="relative flex items-center justify-center px-6 py-16">
-        <div className="w-full max-w-md rounded-3xl bg-white/95 p-8 shadow-2xl shadow-[#f5a25d20]">
+        <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/80 p-8 shadow-2xl shadow-black/50 backdrop-blur">
           <div className="text-center">
-            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">ยินดีต้อนรับกลับ</h1>
-            <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+            <h1 className="text-3xl font-bold text-[var(--color-rose)]">ยินดีต้อนรับกลับ</h1>
+            <p className="mt-2 text-sm text-[var(--color-text)]/70">
               เข้าสู่ระบบเพื่อจัดการคำสั่งซื้อและดูสถานะการจัดส่งของคุณ
             </p>
           </div>
@@ -55,7 +55,7 @@ function LoginContent() {
                 name="email"
                 type="email"
                 placeholder="name@example.com"
-                className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                 required
               />
             </div>
@@ -65,13 +65,13 @@ function LoginContent() {
                 name="password"
                 type="password"
                 placeholder="รหัสผ่าน"
-                className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                 required
               />
             </div>
             <button
               disabled={loading}
-              className="w-full rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f7c68b] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition disabled:cursor-not-allowed disabled:opacity-70"
+              className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
             >
               {loading ? "กำลังเข้าสู่ระบบ..." : "เข้าสู่ระบบ"}
             </button>
@@ -79,7 +79,7 @@ function LoginContent() {
 
           {err && <p className="mt-4 text-sm text-rose-600">{err}</p>}
 
-          <p className="mt-6 text-center text-sm text-[var(--color-choco)]/70">
+          <p className="mt-6 text-center text-sm text-[var(--color-text)]/70">
             ยังไม่มีบัญชี?
             <Link href="/register" className="ml-2 font-semibold text-[var(--color-rose)] hover:text-[var(--color-rose-dark)]">
               สมัครสมาชิกเลย
@@ -95,7 +95,7 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-choco)]/70">
+        <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-text)]/70">
           กำลังโหลดฟอร์มเข้าสู่ระบบ...
         </main>
       }

--- a/app/(site)/login/page.js
+++ b/app/(site)/login/page.js
@@ -77,7 +77,7 @@ function LoginContent() {
             </button>
           </form>
 
-          {err && <p className="mt-4 text-sm text-rose-600">{err}</p>}
+          {err && <p className="mt-4 text-sm text-[var(--color-rose)]">{err}</p>}
 
           <p className="mt-6 text-center text-sm text-[var(--color-text)]/70">
             ยังไม่มีบัญชี?

--- a/app/(site)/orders/[id]/page.jsx
+++ b/app/(site)/orders/[id]/page.jsx
@@ -321,28 +321,32 @@ export default function OrderDetailPage() {
   }
 
   if (loading)
-    return <main className="max-w-3xl mx-auto px-6 py-10 text-[var(--color-choco)]/70">กำลังโหลด...</main>;
+    return (
+      <main className="flex min-h-[60vh] items-center justify-center bg-[var(--color-burgundy-dark)]/60 text-[var(--color-text)]/70">
+        กำลังโหลด...
+      </main>
+    );
 
   if (needsAuth && status !== "loading") {
     return (
       <main className="relative min-h-[70vh] overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
-          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[rgba(240,200,105,0.2)]">
-            <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบก่อนดูรายละเอียด</h1>
-            <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+          <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 p-10 text-center text-[var(--color-text)] shadow-2xl shadow-black/40 backdrop-blur">
+            <h1 className="text-2xl font-semibold text-[var(--color-rose)]">เข้าสู่ระบบก่อนดูรายละเอียด</h1>
+            <p className="mt-3 text-sm text-[var(--color-text)]/75">
               โปรดเข้าสู่ระบบเพื่อยืนยันตัวตนก่อนเข้าถึงรายละเอียดคำสั่งซื้อ
             </p>
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
               >
                 เข้าสู่ระบบ
               </Link>
               <Link
                 href="/register"
-                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/50 px-5 py-3 text-sm font-semibold text-[var(--color-gold)] transition hover:bg-[var(--color-burgundy)]/60"
               >
                 สมัครสมาชิกใหม่
               </Link>
@@ -353,7 +357,7 @@ export default function OrderDetailPage() {
     );
   }
 
-  if (err) return <main className="max-w-3xl mx-auto px-6 py-10 text-rose-600">{err}</main>;
+  if (err) return <main className="max-w-3xl mx-auto px-6 py-10 text-[var(--color-rose)]">{err}</main>;
   if (!order) return null;
 
   const normalizedStatus = normalizeStatus(order.status);
@@ -361,66 +365,66 @@ export default function OrderDetailPage() {
   const paymentText = paymentLabel[paymentStatus] || paymentStatus;
   const paymentBadgeClass =
     paymentStatus === "paid"
-      ? "bg-emerald-100 text-emerald-600"
+      ? "bg-[var(--color-gold)]/20 text-[var(--color-burgundy-dark)]"
       : paymentStatus === "cash"
-      ? "bg-sky-100 text-sky-600"
+      ? "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-text)]/80"
       : paymentStatus === "invalid"
-      ? "bg-rose-100 text-rose-600"
+      ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
       : paymentStatus === "verifying"
-      ? "bg-[#fff5e4] text-[var(--color-choco)]"
-      : "bg-amber-100 text-amber-600";
+      ? "bg-[var(--color-rose)]/10 text-[var(--color-text)]/75"
+      : "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-gold)]/80";
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
-      <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
-      <div className="absolute -bottom-20 left-20 h-72 w-72 rounded-full bg-[#f3d36b]/20 blur-3xl" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.65),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute -bottom-20 left-20 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
       <div className="relative max-w-4xl mx-auto px-6 py-16">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">
+            <h1 className="text-3xl font-bold text-[var(--color-rose)]">
               คำสั่งซื้อ #{(order.id || order._id).slice(-8)}
             </h1>
-            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+            <p className="mt-1 text-sm text-[var(--color-text)]/70">
               อัปเดตล่าสุดเมื่อ {order.updatedAt ? new Date(order.updatedAt).toLocaleString() : "-"}
             </p>
           </div>
           <Link
             href="/orders"
-            className="inline-flex items-center justify-center rounded-full bg-white/80 px-5 py-2 text-sm font-semibold text-[var(--color-rose-dark)] shadow hover:bg-white"
+            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
           >
             ← กลับไปหน้ารายการทั้งหมด
           </Link>
         </div>
 
         <div className="mt-10 grid gap-6 lg:grid-cols-[1.3fr_1fr]">
-          <section className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
+          <section className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
             <header className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-[var(--color-choco)]">สถานะคำสั่งซื้อ</h2>
+              <h2 className="text-lg font-semibold text-[var(--color-text)]">สถานะคำสั่งซื้อ</h2>
               <span
                 className={`rounded-full px-3 py-1 text-xs font-semibold ${
                   normalizedStatus === "cancel"
-                    ? "bg-rose-100 text-rose-600"
+                    ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
                     : normalizedStatus === "success"
-                    ? "bg-emerald-100 text-emerald-600"
-                    : "bg-[#ecfdf5] text-emerald-600"
+                    ? "bg-[var(--color-gold)]/20 text-[var(--color-burgundy-dark)]"
+                    : "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-text)]/80"
                 }`}
               >
                 {statusText}
               </span>
             </header>
 
-            <div className="mt-4 grid gap-3 text-sm text-[var(--color-choco)]/80">
-              <div className="flex items-center justify-between rounded-2xl bg-[#fff6ee] px-4 py-3">
+            <div className="mt-4 grid gap-3 text-sm text-[var(--color-text)]/80">
+              <div className="flex items-center justify-between rounded-2xl bg-[var(--color-burgundy-dark)]/35 px-4 py-3">
                 <span>การชำระเงิน</span>
                 <span className={`rounded-full px-3 py-1 text-xs font-semibold ${paymentBadgeClass}`}>
                   {paymentText}
                 </span>
               </div>
-              <div className="flex items-center justify-between rounded-2xl bg-[#fef9ff] px-4 py-3">
+              <div className="flex items-center justify-between rounded-2xl bg-[var(--color-burgundy-dark)]/30 px-4 py-3">
                 <span>ช่องทาง</span>
-                <span className="font-medium text-[var(--color-rose-dark)]">
+                <span className="font-medium text-[var(--color-rose)]">
                   {paymentStatus === "cash"
                     ? "เงินสดหน้างาน"
                     : order.payment?.method === "bank"
@@ -429,13 +433,13 @@ export default function OrderDetailPage() {
                 </span>
               </div>
               {typeof order.payment?.amountPaid === "number" ? (
-                <div className="flex items-center justify-between rounded-2xl bg-[#ecfdf5] px-4 py-3">
+                <div className="flex items-center justify-between rounded-2xl bg-[var(--color-burgundy-dark)]/35 px-4 py-3">
                   <span>จำนวนที่โอน</span>
-                  <span className="font-semibold text-emerald-600">฿{order.payment.amountPaid.toFixed(2)}</span>
+                  <span className="font-semibold text-[var(--color-gold)]">฿{order.payment.amountPaid.toFixed(2)}</span>
                 </div>
               ) : null}
               {order.payment?.confirmedAt ? (
-                <div className="flex items-center justify-between rounded-2xl bg-white px-4 py-3">
+                <div className="flex items-center justify-between rounded-2xl bg-[var(--color-burgundy-dark)]/40 px-4 py-3">
                   <span>ยืนยันเมื่อ</span>
                   <span>{new Date(order.payment.confirmedAt).toLocaleString()}</span>
                 </div>
@@ -445,18 +449,18 @@ export default function OrderDetailPage() {
             {order.payment?.slip ? (
               <div className="mt-6">
                 <h3 className="text-sm font-semibold text-[var(--color-choco)]">สลิปการโอน</h3>
-                <div className="mt-3 overflow-hidden rounded-2xl border border-white/60 shadow-inner">
+                <div className="mt-3 overflow-hidden rounded-2xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy-dark)]/45 shadow-inner">
                   <img
                     src={order.payment.slip}
                     alt={order.payment.slipFilename || "หลักฐานการโอน"}
-                    className="max-h-[420px] w-full object-contain bg-white"
+                    className="max-h-[420px] w-full object-contain"
                   />
                 </div>
               </div>
             ) : null}
 
             {!isPaid ? (
-              <div className="mt-6 space-y-4 rounded-2xl border border-[var(--color-rose)]/25 bg-[#fff9fb] p-5">
+              <div className="mt-6 space-y-4 rounded-2xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy-dark)]/30 p-5">
                 <div>
                   <h3 className="text-base font-semibold text-[var(--color-choco)]">ชำระเงินสำหรับคำสั่งซื้อนี้</h3>
                   <p className="mt-1 text-xs text-[var(--color-choco)]/70">
@@ -465,11 +469,11 @@ export default function OrderDetailPage() {
                 </div>
 
                 {paymentStatus === "verifying" ? (
-                  <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2 text-xs font-semibold text-amber-700">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/35 bg-[rgba(240,200,105,0.12)] px-4 py-2 text-xs font-semibold text-[var(--color-gold)]">
                     สลิปของคุณอยู่ระหว่างการตรวจสอบ หากต้องการแก้ไขสามารถอัปโหลดใหม่ได้เลย
                   </div>
                 ) : paymentStatus === "invalid" ? (
-                  <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-xs font-semibold text-rose-700">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/40 bg-[rgba(120,32,32,0.55)] px-4 py-2 text-xs font-semibold text-[var(--color-rose)]">
                     ยอดโอนที่แจ้งมาไม่ตรงกับยอดที่ต้องชำระ กรุณาแนบสลิปใหม่อีกครั้ง
                   </div>
                 ) : null}
@@ -483,21 +487,21 @@ export default function OrderDetailPage() {
                         type="button"
                         onClick={() => handleSelectMethod(option.value)}
                         disabled={updatingMethod || confirming || paymentStatus === "cash" || paymentStatus === "verifying"}
-                        className={`rounded-2xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30 ${
+                        className={`rounded-2xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/35 ${
                           active
-                            ? "border-[var(--color-rose)] bg-[#fff1f5] text-[var(--color-rose-dark)] shadow"
-                            : "border-[var(--color-rose)]/35 bg-white text-[var(--color-choco)]/80"
+                            ? "border-[var(--color-rose)] bg-[rgba(240,200,105,0.16)] text-[var(--color-rose)] shadow-lg shadow-black/40"
+                            : "border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/55 text-[var(--color-text)]/80"
                         } ${updatingMethod || confirming ? "cursor-wait" : ""}`}
                       >
                         <div className="font-semibold">{option.label}</div>
-                        <div className="mt-1 text-xs text-[var(--color-choco)]/60">{option.description}</div>
+                        <div className="mt-1 text-xs text-[var(--color-text)]/70">{option.description}</div>
                       </button>
                     );
                   })}
                 </div>
 
                 {loadingPayment ? (
-                  <div className="rounded-2xl border border-dashed border-[var(--color-rose)]/40 bg-white/70 px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                  <div className="rounded-2xl border border-dashed border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/35 px-4 py-3 text-sm text-[var(--color-text)]/75">
                     กำลังโหลดรายละเอียดการชำระเงิน...
                   </div>
                 ) : paymentInfo?.promptpay ? (
@@ -513,7 +517,7 @@ export default function OrderDetailPage() {
                     ) : null}
                   </div>
                 ) : amountDue <= 0 ? (
-                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/30 px-4 py-3 text-sm text-[var(--color-text)]/75">
                     ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                   </div>
                 ) : null}
@@ -528,13 +532,13 @@ export default function OrderDetailPage() {
                       readOnly
                       value={transferAmount}
                       onChange={(e) => setTransferAmount(e.target.value)}
-                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-2 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                       placeholder={`ยอดที่ต้องชำระ ฿${fmt(amountDue)}`}
                     />
                     <p className="text-xs text-[var(--color-choco)]/60">ยอดที่ต้องชำระทั้งหมด ฿{fmt(amountDue)}</p>
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/30 px-4 py-3 text-sm text-[var(--color-text)]/75">
                     ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                   </div>
                 )}
@@ -550,8 +554,8 @@ export default function OrderDetailPage() {
                       const file = e.dataTransfer.files?.[0];
                       await processSlipFile(file);
                     }}
-                    className={`group relative flex flex-col items-center justify-center rounded-2xl border-2 border-dashed p-6 transition 
-                      ${slipData ? "border-emerald-300 bg-emerald-50/40" : "border-[var(--color-rose)]/30 bg-white hover:border-[var(--color-rose)]/50 hover:bg-[var(--color-rose)]/5"}`}
+                    className={`group relative flex flex-col items-center justify-center rounded-2xl border-2 border-dashed p-6 transition
+                      ${slipData ? "border-[var(--color-rose)] bg-[rgba(240,200,105,0.16)]" : "border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/45 hover:border-[var(--color-rose)]/50 hover:bg-[var(--color-burgundy-dark)]/35"}`}
                   >
                     <input
                       id="slip"
@@ -580,7 +584,7 @@ export default function OrderDetailPage() {
                       </label>
                     ) : (
                       <div className="w-full">
-                        <div className="relative overflow-hidden rounded-xl border bg-white">
+                        <div className="relative overflow-hidden rounded-xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/45">
                           <img
                             src={slipData}
                             alt={slipName || "หลักฐานการโอน"}
@@ -589,7 +593,7 @@ export default function OrderDetailPage() {
                           <button
                             type="button"
                             onClick={() => { setSlipData(""); setSlipName(""); }}
-                            className="absolute right-2 top-2 inline-flex items-center rounded-full bg-white/90 px-2 py-1 text-xs font-medium text-rose-600 shadow hover:bg-white"
+                            className="absolute right-2 top-2 inline-flex items-center rounded-full bg-[var(--color-burgundy-dark)]/60 px-2 py-1 text-xs font-medium text-[var(--color-rose)] shadow hover:bg-[var(--color-burgundy-dark)]/45"
                             aria-label="ลบสลิป"
                             title="ลบสลิป"
                           >
@@ -604,7 +608,7 @@ export default function OrderDetailPage() {
                           </div>
                           <label
                             htmlFor="slip"
-                            className="inline-flex cursor-pointer items-center justify-center rounded-full border border-[var(--color-rose)]/40 bg-white px-4 py-1.5 text-xs font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+                            className="inline-flex cursor-pointer items-center justify-center rounded-full border border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/45 px-4 py-1.5 text-xs font-semibold text-[var(--color-rose)] hover:bg-[var(--color-burgundy-dark)]/30"
                           >
                             <ImageIcon className="mr-1.5 h-3.5 w-3.5" />
                             เปลี่ยนรูป
@@ -622,7 +626,7 @@ export default function OrderDetailPage() {
                     type="text"
                     value={reference}
                     onChange={(e) => setReference(e.target.value)}
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-2 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                     placeholder="เช่น เลขที่รายการ หรือเลขอ้างอิงจากแอปธนาคาร"
                   />
                 </div>
@@ -638,21 +642,21 @@ export default function OrderDetailPage() {
                   }
                   className={`inline-flex w-full items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                     confirming || updatingMethod || loadingPayment || !slipData || (needsAmountInput && !transferAmount)
-                      ? "cursor-not-allowed bg-[#f2c8a5]"
+                      ? "cursor-not-allowed bg-[var(--color-burgundy-dark)]/30"
                       : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
                   }`}
                 >
                   {confirming ? "กำลังยืนยัน..." : updatingMethod ? "กำลังอัปเดตวิธีชำระเงิน..." : "ยืนยันการชำระเงิน"}
                 </button>
 
-                {actionSuccess ? <div className="text-sm text-emerald-600">{actionSuccess}</div> : null}
-                {actionErr ? <div className="text-sm text-rose-600">{actionErr}</div> : null}
+                {actionSuccess ? <div className="text-sm text-[var(--color-gold)]">{actionSuccess}</div> : null}
+                {actionErr ? <div className="text-sm text-[var(--color-rose)]">{actionErr}</div> : null}
               </div>
             ) : null}
           </section>
 
           <section className="space-y-6">
-            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายละเอียดยอดชำระ</h2>
               <div className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
                 <div className="flex justify-between">
@@ -660,7 +664,7 @@ export default function OrderDetailPage() {
                   <span>฿{order.subtotal}</span>
                 </div>
                 {order.discount ? (
-                  <div className="flex justify-between text-emerald-600">
+                  <div className="flex justify-between text-[var(--color-gold)]">
                     <span>ส่วนลด</span>
                     <span>-฿{order.discount}</span>
                   </div>
@@ -672,7 +676,7 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">ข้อมูลจัดส่ง</h2>
               <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/80">
                 <div>
@@ -680,7 +684,7 @@ export default function OrderDetailPage() {
                   <div>{order.customer?.phone || ""}</div>
                   <div>{order.customer?.email || ""}</div>
                 </div>
-                <div className="rounded-2xl bg-[#fff6ee] p-4 text-sm leading-relaxed">
+                <div className="rounded-2xl bg-[var(--color-burgundy-dark)]/35 p-4 text-sm leading-relaxed">
                   <p>{order.shipping?.address1}</p>
                   {order.shipping?.address2 ? <p>{order.shipping.address2}</p> : null}
                   <p>
@@ -693,43 +697,26 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-                  <div className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
-            <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
-          <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
-            {order.items.map((it, idx) => (
-              <div
-                key={`${order.id || order._id}-${it.productId || it.title}-${idx}`}
-                className="flex flex-col gap-2 py-4 text-sm text-[var(--color-choco)]/80 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <div className="font-medium text-[var(--color-choco)]">{it.title}</div>
-                  <div className="text-xs text-[var(--color-choco)]/60">จำนวน {it.qty}</div>
-                </div>
-                <div className="text-sm font-semibold text-[var(--color-rose-dark)]">฿{(it.price || 0) * (it.qty || 0)}</div>
+            <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-6 shadow-2xl shadow-black/40 backdrop-blur">
+              <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
+              <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
+                {order.items.map((it, idx) => (
+                  <div
+                    key={`${order.id || order._id}-${it.productId || it.title}-${idx}`}
+                    className="flex flex-col gap-2 py-4 text-sm text-[var(--color-choco)]/80 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <div className="font-medium text-[var(--color-choco)]">{it.title}</div>
+                      <div className="text-xs text-[var(--color-choco)]/60">จำนวน {it.qty}</div>
+                    </div>
+                    <div className="text-sm font-semibold text-[var(--color-rose-dark)]">฿{(it.price || 0) * (it.qty || 0)}</div>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-          </div>
+            </div>
           </section>
         </div>
 
-        {/* <section className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
-          <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
-          <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
-            {order.items.map((it, idx) => (
-              <div
-                key={`${order.id || order._id}-${it.productId || it.title}-${idx}`}
-                className="flex flex-col gap-2 py-4 text-sm text-[var(--color-choco)]/80 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <div className="font-medium text-[var(--color-choco)]">{it.title}</div>
-                  <div className="text-xs text-[var(--color-choco)]/60">จำนวน {it.qty}</div>
-                </div>
-                <div className="text-sm font-semibold text-[var(--color-rose-dark)]">฿{(it.price || 0) * (it.qty || 0)}</div>
-              </div>
-            ))}
-          </div>
-        </section> */}
       </div>
     </main>
   );

--- a/app/(site)/orders/[id]/page.jsx
+++ b/app/(site)/orders/[id]/page.jsx
@@ -328,7 +328,7 @@ export default function OrderDetailPage() {
       <main className="relative min-h-[70vh] overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
-          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[#f5a25d20]">
+          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[rgba(240,200,105,0.2)]">
             <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบก่อนดูรายละเอียด</h1>
             <p className="mt-3 text-sm text-[var(--color-choco)]/70">
               โปรดเข้าสู่ระบบเพื่อยืนยันตัวตนก่อนเข้าถึงรายละเอียดคำสั่งซื้อ
@@ -336,7 +336,7 @@ export default function OrderDetailPage() {
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
               >
                 เข้าสู่ระบบ
               </Link>
@@ -373,7 +373,7 @@ export default function OrderDetailPage() {
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
-      <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[#f5a25d]/15 blur-3xl" />
+      <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
       <div className="absolute -bottom-20 left-20 h-72 w-72 rounded-full bg-[#f3d36b]/20 blur-3xl" />
 
       <div className="relative max-w-4xl mx-auto px-6 py-16">
@@ -395,7 +395,7 @@ export default function OrderDetailPage() {
         </div>
 
         <div className="mt-10 grid gap-6 lg:grid-cols-[1.3fr_1fr]">
-          <section className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f5a25d15]">
+          <section className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
             <header className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">สถานะคำสั่งซื้อ</h2>
               <span
@@ -486,7 +486,7 @@ export default function OrderDetailPage() {
                         className={`rounded-2xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30 ${
                           active
                             ? "border-[var(--color-rose)] bg-[#fff1f5] text-[var(--color-rose-dark)] shadow"
-                            : "border-[#f4c689]/60 bg-white text-[var(--color-choco)]/80"
+                            : "border-[var(--color-rose)]/35 bg-white text-[var(--color-choco)]/80"
                         } ${updatingMethod || confirming ? "cursor-wait" : ""}`}
                       >
                         <div className="font-semibold">{option.label}</div>
@@ -503,7 +503,7 @@ export default function OrderDetailPage() {
                 ) : paymentInfo?.promptpay ? (
                   <QrBox payload={paymentInfo.promptpay.payload} amount={paymentInfo.promptpay.amount} title="สแกนเพื่อชำระเงิน" />
                 ) : paymentMethod === "bank" && paymentInfo?.bankAccount ? (
-                  <div className="space-y-2 rounded-2xl border border-[#f4c689]/50 bg-[#fff6ed] p-4 text-sm text-[var(--color-choco)]">
+                  <div className="space-y-2 rounded-2xl border border-[#f4c689]/50 bg-[rgba(240,200,105,0.12)] p-4 text-sm text-[var(--color-choco)]">
                     <div className="font-semibold text-[var(--color-rose-dark)]">รายละเอียดบัญชีสำหรับโอน</div>
                     <div>ธนาคาร: {paymentInfo.bankAccount.bank}</div>
                     <div>เลขบัญชี: {paymentInfo.bankAccount.number}</div>
@@ -513,7 +513,7 @@ export default function OrderDetailPage() {
                     ) : null}
                   </div>
                 ) : amountDue <= 0 ? (
-                  <div className="rounded-2xl border border-[#f4c689]/40 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
                     ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                   </div>
                 ) : null}
@@ -528,13 +528,13 @@ export default function OrderDetailPage() {
                       readOnly
                       value={transferAmount}
                       onChange={(e) => setTransferAmount(e.target.value)}
-                      className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                       placeholder={`ยอดที่ต้องชำระ ฿${fmt(amountDue)}`}
                     />
                     <p className="text-xs text-[var(--color-choco)]/60">ยอดที่ต้องชำระทั้งหมด ฿{fmt(amountDue)}</p>
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-[#f4c689]/40 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
+                  <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[#fff7ef] px-4 py-3 text-sm text-[var(--color-choco)]/70">
                     ออเดอร์นี้ไม่มียอดที่ต้องชำระเพิ่มเติม
                   </div>
                 )}
@@ -574,7 +574,7 @@ export default function OrderDetailPage() {
                             รองรับไฟล์รูปภาพ (PNG, JPG, JPEG)
                           </div>
                         </div>
-                        <span className="inline-flex items-center rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-[#f5a25d33] group-hover:shadow-md">
+                        <span className="inline-flex items-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-4 py-2 text-xs font-semibold text-white shadow-sm shadow-[rgba(240,200,105,0.33)] group-hover:shadow-md">
                           เลือกไฟล์สลิป
                         </span>
                       </label>
@@ -622,7 +622,7 @@ export default function OrderDetailPage() {
                     type="text"
                     value={reference}
                     onChange={(e) => setReference(e.target.value)}
-                    className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
+                    className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                     placeholder="เช่น เลขที่รายการ หรือเลขอ้างอิงจากแอปธนาคาร"
                   />
                 </div>
@@ -636,10 +636,10 @@ export default function OrderDetailPage() {
                     !slipData ||
                     (needsAmountInput && !transferAmount)
                   }
-                  className={`inline-flex w-full items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition ${
+                  className={`inline-flex w-full items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                     confirming || updatingMethod || loadingPayment || !slipData || (needsAmountInput && !transferAmount)
                       ? "cursor-not-allowed bg-[#f2c8a5]"
-                      : "bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] hover:shadow-xl"
+                      : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
                   }`}
                 >
                   {confirming ? "กำลังยืนยัน..." : updatingMethod ? "กำลังอัปเดตวิธีชำระเงิน..." : "ยืนยันการชำระเงิน"}
@@ -652,7 +652,7 @@ export default function OrderDetailPage() {
           </section>
 
           <section className="space-y-6">
-            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f5a25d15]">
+            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายละเอียดยอดชำระ</h2>
               <div className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
                 <div className="flex justify-between">
@@ -672,7 +672,7 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f5a25d15]">
+            <div className="rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
               <h2 className="text-lg font-semibold text-[var(--color-choco)]">ข้อมูลจัดส่ง</h2>
               <div className="mt-4 space-y-2 text-sm text-[var(--color-choco)]/80">
                 <div>
@@ -693,7 +693,7 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-                  <div className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f5a25d15]">
+                  <div className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
             <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
           <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
             {order.items.map((it, idx) => (
@@ -713,7 +713,7 @@ export default function OrderDetailPage() {
           </section>
         </div>
 
-        {/* <section className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[#f5a25d15]">
+        {/* <section className="mt-10 rounded-3xl bg-white/95 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
           <h2 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h2>
           <div className="mt-4 divide-y divide-[var(--color-rose)]/10">
             {order.items.map((it, idx) => (

--- a/app/(site)/orders/page.jsx
+++ b/app/(site)/orders/page.jsx
@@ -98,7 +98,7 @@ export default function OrdersPage() {
 
   if (loading)
     return (
-      <main className="flex min-h-[60vh] items-center justify-center text-[var(--color-choco)]/70">
+      <main className="flex min-h-[60vh] items-center justify-center bg-[var(--color-burgundy-dark)]/60 text-[var(--color-text)]/70">
         กำลังโหลด...
       </main>
     );
@@ -106,23 +106,23 @@ export default function OrdersPage() {
   if (needsAuth && status !== "loading") {
     return (
       <main className="relative min-h-[70vh] overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
-          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[rgba(240,200,105,0.2)]">
-            <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบเพื่อดูคำสั่งซื้อ</h1>
-            <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+          <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 p-10 text-center text-[var(--color-text)] shadow-2xl shadow-black/40 backdrop-blur">
+            <h1 className="text-2xl font-semibold text-[var(--color-rose)]">เข้าสู่ระบบเพื่อดูคำสั่งซื้อ</h1>
+            <p className="mt-3 text-sm text-[var(--color-text)]/75">
               บัญชีผู้ใช้จำเป็นสำหรับเชื่อมคำสั่งซื้อกับคุณ กรุณาเข้าสู่ระบบหรือสมัครสมาชิกใหม่เพื่อดูประวัติการสั่งซื้อทั้งหมดของคุณ
             </p>
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
               >
                 เข้าสู่ระบบ
               </Link>
               <Link
                 href="/register"
-                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-rose-dark)] hover:bg-[var(--color-rose)]/10"
+                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/50 px-5 py-3 text-sm font-semibold text-[var(--color-gold)] transition hover:bg-[var(--color-burgundy)]/60"
               >
                 สมัครสมาชิกใหม่
               </Link>
@@ -142,21 +142,21 @@ export default function OrdersPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
-      <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
-      <div className="absolute -bottom-20 left-12 h-72 w-72 rounded-full bg-[#f3d36b]/20 blur-3xl" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.65),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute -bottom-20 left-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">คำสั่งซื้อของฉัน</h1>
-            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+            <h1 className="text-3xl font-bold text-[var(--color-rose)]">คำสั่งซื้อของฉัน</h1>
+            <p className="mt-1 text-sm text-[var(--color-text)]/70">
               ติดตามสถานะคำสั่งซื้อและดูรายละเอียดการชำระเงินย้อนหลังได้ที่นี่
             </p>
           </div>
           <Link
             href="/"
-            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
+            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
           >
             เลือกสินค้าเพิ่ม
           </Link>
@@ -197,7 +197,7 @@ export default function OrdersPage() {
                         #{orderId.slice(-8)}
                       </div>
                     </div>
-                    <span className="rounded-full bg-[#fff5e4] px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/80">
+                    <span className="rounded-full bg-[var(--color-burgundy-dark)]/45 px-3 py-1 text-xs font-semibold text-[var(--color-text)]/80">
                       {createdAt ? createdAt.toLocaleDateString() : "-"}
                     </span>
                   </div>
@@ -212,10 +212,10 @@ export default function OrdersPage() {
                       <span
                         className={`rounded-full px-3 py-1 text-xs font-semibold ${
                           normalizedStatus === "cancel"
-                            ? "bg-rose-100 text-rose-600"
+                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
                             : normalizedStatus === "success"
-                            ? "bg-emerald-100 text-emerald-600"
-                            : "bg-[#ecfdf5] text-emerald-600"
+                            ? "bg-[var(--color-gold)]/20 text-[var(--color-burgundy-dark)]"
+                            : "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-text)]/80"
                         }`}
                       >
                         {displayStatus}
@@ -226,14 +226,14 @@ export default function OrdersPage() {
                       <span
                         className={`rounded-full px-2 py-1 font-semibold ${
                           paymentStatus === "paid"
-                            ? "bg-emerald-100 text-emerald-600"
+                            ? "bg-[var(--color-gold)]/20 text-[var(--color-burgundy-dark)]"
                             : paymentStatus === "cash"
-                            ? "bg-sky-100 text-sky-600"
+                            ? "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-text)]/80"
                             : paymentStatus === "invalid"
-                            ? "bg-rose-100 text-rose-600"
+                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
                             : paymentStatus === "verifying"
-                            ? "bg-[#fff5e4] text-[var(--color-choco)]"
-                            : "bg-amber-100 text-amber-600"
+                            ? "bg-[var(--color-rose)]/10 text-[var(--color-text)]/75"
+                            : "bg-[var(--color-burgundy-dark)]/40 text-[var(--color-gold)]/80"
                         }`}
                       >
                         {displayPayment}

--- a/app/(site)/orders/page.jsx
+++ b/app/(site)/orders/page.jsx
@@ -108,7 +108,7 @@ export default function OrdersPage() {
       <main className="relative min-h-[70vh] overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
-          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[#f5a25d20]">
+          <div className="w-full max-w-md rounded-3xl bg-white/90 p-10 text-center shadow-xl shadow-[rgba(240,200,105,0.2)]">
             <h1 className="text-2xl font-semibold text-[var(--color-rose-dark)]">เข้าสู่ระบบเพื่อดูคำสั่งซื้อ</h1>
             <p className="mt-3 text-sm text-[var(--color-choco)]/70">
               บัญชีผู้ใช้จำเป็นสำหรับเชื่อมคำสั่งซื้อกับคุณ กรุณาเข้าสู่ระบบหรือสมัครสมาชิกใหม่เพื่อดูประวัติการสั่งซื้อทั้งหมดของคุณ
@@ -116,7 +116,7 @@ export default function OrdersPage() {
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
               >
                 เข้าสู่ระบบ
               </Link>
@@ -143,7 +143,7 @@ export default function OrdersPage() {
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#fff4e6] via-[#fff7f0] to-[#ffe1d0]" />
-      <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[#f5a25d]/15 blur-3xl" />
+      <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[var(--color-rose)]/15 blur-3xl" />
       <div className="absolute -bottom-20 left-12 h-72 w-72 rounded-full bg-[#f3d36b]/20 blur-3xl" />
 
       <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
@@ -156,14 +156,14 @@ export default function OrdersPage() {
           </div>
           <Link
             href="/"
-            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
           >
             เลือกสินค้าเพิ่ม
           </Link>
         </div>
 
         {orders.length === 0 ? (
-          <div className="mt-10 rounded-3xl bg-white/85 p-10 text-center shadow-lg shadow-[#f5a25d22]">
+          <div className="mt-10 rounded-3xl bg-white/85 p-10 text-center shadow-lg shadow-[rgba(240,200,105,0.22)]">
             <p className="text-lg font-semibold text-[var(--color-choco)]">
               ยังไม่มีคำสั่งซื้อ
             </p>
@@ -188,7 +188,7 @@ export default function OrdersPage() {
                 <Link
                   href={`/orders/${orderId}`}
                   key={orderId}
-                  className="group block rounded-3xl bg-white/90 p-6 shadow-lg shadow-[#f5a25d1a] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+                  className="group block rounded-3xl bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.1)] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div>

--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -26,32 +26,32 @@ export default async function HomePage() {
   return (
     <main className="min-h-screen">
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-[#fff3df] via-[#fde7b8] to-[#f6c08c]" />
-        <div className="absolute -top-20 -right-10 h-72 w-72 rounded-full bg-[#fbd8a4]/60 blur-3xl" />
-        <div className="absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-[#f3c0a6]/40 blur-3xl" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[#5d1f1f]" />
+        <div className="absolute -top-20 -right-10 h-72 w-72 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+        <div className="absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
         <div className="relative max-w-screen-xl mx-auto px-6 lg:px-8 py-20 grid gap-12 lg:grid-cols-2 items-center">
           <div className="space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-sm font-medium text-[var(--color-rose-dark)] shadow">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/70 px-4 py-1 text-sm font-medium text-[var(--color-gold)] shadow">
               นึ่งสดทุกวัน • ส่งฟรีในตัวเมืองลำพูน
             </span>
-            <h1 className="text-4xl sm:text-5xl font-extrabold leading-tight text-[var(--color-rose-dark)]">
-              ซาลาเปาและขนมจีบร้อนๆ 
+            <h1 className="text-4xl sm:text-5xl font-extrabold leading-tight text-[var(--color-rose)]">
+              ซาลาเปาและขนมจีบร้อนๆ
             </h1>
-            <p className="text-base sm:text-lg text-[var(--color-choco)]/80 max-w-xl">
+            <p className="text-base sm:text-lg text-[var(--color-text)]/80 max-w-xl">
               ซาลาเปาไส้หมูสับ หมูสับไข่เค็ม ครีม ถั่วดำ และเมนูพิเศษ
               พร้อมขนมจีบกุ้งและหมูที่นึ่งสดใหม่ให้คุณอร่อยได้ทุกมื้อ
             </p>
             <div className="flex flex-col sm:flex-row sm:flex-wrap gap-4">
               <a
                 href="#menu"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:bg-[var(--color-rose-dark)]"
               >
                 เลือกซาลาเปาเลย
               </a>
               <a
                 href="/preorder"
-                className="inline-flex items-center justify-center rounded-full border border-white/60 bg-white/70 px-6 py-3 text-sm font-semibold text-[var(--color-rose-dark)] shadow hover:bg-white"
+                className="inline-flex items-center justify-center rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-6 py-3 text-sm font-semibold text-[var(--color-rose)] shadow hover:bg-[var(--color-burgundy)]"
               >
                 สั่งเบรกเช้า & สั่งล่วงหน้า
               </a>
@@ -67,7 +67,7 @@ export default async function HomePage() {
               {["นึ่งสดทุกวัน", "หมูคัดพิเศษ", "ส่งไวในเมือง"].map((item) => (
                 <div
                   key={item}
-                  className="text-center rounded-2xl bg-white/70 px-4 py-3 text-sm font-medium text-[var(--color-choco)] shadow"
+                  className="text-center rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-3 text-sm font-medium text-[var(--color-gold)] shadow"
                 >
                   {item}
                 </div>
@@ -76,18 +76,18 @@ export default async function HomePage() {
           </div>
 
           <div className="relative flex justify-center">
-            <div className="relative h-[320px] w-[320px] sm:h-[360px] sm:w-[360px] rounded-[48%] bg-gradient-to-br from-white/80 via-white to-[#fff4e6] shadow-2xl shadow-[#f5a25d22] flex items-center justify-center">
-              <div className="absolute -top-8 right-8 h-16 w-16 rounded-full bg-[#fcd9b6] shadow-lg shadow-[#fcd9b6]/50" />
-              <div className="absolute -bottom-6 left-10 h-20 w-20 rounded-full bg-[#f5be9a] shadow-lg shadow-[#f5be9a]/50" />
-              <div className="absolute top-10 left-6 h-12 w-12 rounded-full border-4 border-dashed border-white/70" />
+            <div className="relative h-[320px] w-[320px] sm:h-[360px] sm:w-[360px] rounded-[48%] bg-gradient-to-br from-[var(--color-burgundy)] via-[#3c1212] to-[var(--color-burgundy-dark)] shadow-2xl shadow-black/50 flex items-center justify-center">
+              <div className="absolute -top-8 right-8 h-16 w-16 rounded-full bg-[var(--color-rose)]/30 shadow-lg shadow-[var(--color-rose)]/40" />
+              <div className="absolute -bottom-6 left-10 h-20 w-20 rounded-full bg-[var(--color-rose-dark)]/30 shadow-lg shadow-[var(--color-rose-dark)]/40" />
+              <div className="absolute top-10 left-6 h-12 w-12 rounded-full border-4 border-dashed border-[var(--color-rose)]/50" />
               <div className="text-center px-10">
-                <p className="text-lg font-semibold text-[var(--color-rose-dark)]">
+                <p className="text-lg font-semibold text-[var(--color-rose)]">
                   เมนูขายดี!
                 </p>
-                <p className="mt-1 text-2xl font-black text-[var(--color-choco)]">
+                <p className="mt-1 text-2xl font-black text-[var(--color-text)]">
                   ซาลาเปาหมูสับไข่เค็ม
                 </p>
-                <p className="mt-4 text-sm text-[var(--color-choco)]/70">
+                <p className="mt-4 text-sm text-[var(--color-text)]/70">
                   หมูสับแน่นๆ พร้อมไข่เค็มเต็มคำ นึ่งด้วยแป้งสูตรนุ่มพิเศษหอมละมุน
                 </p>
               </div>
@@ -121,14 +121,14 @@ export default async function HomePage() {
 
         <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {products.length === 0 ? (
-            <div className="col-span-full rounded-3xl bg-white/90 p-10 text-center text-[var(--color-choco)]/70 shadow-lg shadow-[#f5a25d20]">
+            <div className="col-span-full rounded-3xl bg-white/90 p-10 text-center text-[var(--color-choco)]/70 shadow-lg shadow-[rgba(240,200,105,0.2)]">
               เมนูซาลาเปากำลังนึ่งอยู่ รอสักครู่นะคะ 🥟
             </div>
           ) : (
             products.map((p) => (
               <div
                 key={p._id}
-                className="group relative flex h-full flex-col rounded-3xl bg-white/90 shadow-lg shadow-[#f5a25d20] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+                className="group relative flex h-full flex-col rounded-3xl bg-white/90 shadow-lg shadow-[rgba(240,200,105,0.2)] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
               >
                 <div className="relative overflow-hidden rounded-t-3xl">
                   <div className="aspect-square w-full bg-gradient-to-br from-[#ffe5d0] via-[#fff] to-[#fff2e2] flex items-center justify-center">
@@ -174,9 +174,9 @@ export default async function HomePage() {
             (title, idx) => (
               <div
                 key={title}
-                className="rounded-3xl bg-white p-8 shadow-md shadow-[#f5a25d15]"
+                className="rounded-3xl bg-white p-8 shadow-md shadow-[rgba(240,200,105,0.08)]"
               >
-                {/* <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[#f5a25d] to-[#f3d36b] text-white text-xl shadow">
+                {/* <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[var(--color-rose)] to-[var(--color-gold)] text-white text-xl shadow">
                   {idx === 0 ? "👩‍🍳" : idx === 1 ? "👐" : "🌾"}
                 </div> */}
                 <h3 className="mt-6 text-xl font-semibold text-[var(--color-choco)]">

--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -96,93 +96,97 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section id="menu" className="max-w-screen-xl mx-auto px-6 lg:px-8 py-16">
-        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
-          <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--color-rose)]">
-              Bao & Dim Sum
-            </p>
-            <h2 className="mt-2 text-3xl font-bold text-[var(--color-choco)]">
-              เมนูซาลาเปา & ขนมจีบวันนี้
-            </h2>
-            {/* <p className="mt-2 text-[var(--color-choco)]/70 max-w-2xl">
-              {/* คัดสรรวัตถุดิบธรรมชาติจากฟาร์มท้องถิ่น ผสมผสานความพิถีพิถันในการอบจนได้ขนมสดใหม่ หวานกำลังดี พร้อมส่งถึงคุณทุกเช้า
-            </p> */}
-          </div>
-          <div className="flex gap-3">
-            <span className="inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-[var(--color-choco)] shadow">
-              🥟 เมนูอาจจะมีการเปลี่ยนแปลงในแต่ละวัน
-            </span>
-            {/* <span className="inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-[var(--color-choco)] shadow">
-              ☕ เซตอาหารเช้า
-            </span> */}
-          </div>
-        </div>
 
-        <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {products.length === 0 ? (
-            <div className="col-span-full rounded-3xl bg-white/90 p-10 text-center text-[var(--color-choco)]/70 shadow-lg shadow-[rgba(240,200,105,0.2)]">
-              เมนูซาลาเปากำลังนึ่งอยู่ รอสักครู่นะคะ 🥟
+
+      <section id="menu" className="relative overflow-hidden py-16">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_80%_20%,rgba(58,16,16,0.7),transparent_60%),linear-gradient(135deg,rgba(20,2,2,0.9),rgba(76,25,18,0.85))]" />
+        <div className="relative mx-auto flex max-w-screen-xl flex-col gap-12 px-6 lg:px-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[var(--color-rose)]/90">
+                Bao & Dim Sum
+              </p>
+              <h2 className="mt-2 text-3xl font-bold text-[var(--color-rose)]">
+                เมนูซาลาเปา & ขนมจีบวันนี้
+              </h2>
+              {/* <p className="mt-2 text-[var(--color-text)]/70 max-w-2xl">คำอธิบายเพิ่มเติม</p> */}
             </div>
-          ) : (
-            products.map((p) => (
-              <div
-                key={p._id}
-                className="group relative flex h-full flex-col rounded-3xl bg-white/90 shadow-lg shadow-[rgba(240,200,105,0.2)] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
-              >
-                <div className="relative overflow-hidden rounded-t-3xl">
-                  <div className="aspect-square w-full bg-gradient-to-br from-[#ffe5d0] via-[#fff] to-[#fff2e2] flex items-center justify-center">
-                    {p.images?.[0] ? (
-                      <img
-                        src={p.images[0]}
-                        alt={p.title}
-                        className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                      />
-                    ) : (
-                      <span className="text-4xl">🥟</span>
-                    )}
-                  </div>
-                  <div className="absolute top-4 left-4 rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-[var(--color-rose-dark)] shadow">
-                    เมนูแนะนำ
-                  </div>
-                </div>
-                <div className="flex flex-1 flex-col gap-3 p-6">
-                  <div>
-                    <h3 className="text-xl font-semibold text-[var(--color-choco)]">
-                      {p.title}
-                    </h3>
-                    <p className="mt-1 text-sm text-[var(--color-choco)]/70 line-clamp-3">
-                      {p.description}
-                    </p>
-                  </div>
-                  <div className="mt-auto flex items-center justify-between pt-2">
-                    <span className="text-lg font-bold text-[var(--color-rose-dark)]">
-                      ฿{p.price}
-                    </span>
-                    <AddToCartButton product={p} />
-                  </div>
-                </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <span className="inline-flex items-center rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/70 px-4 py-2 text-sm font-medium text-[var(--color-gold)] shadow">
+                🥟 เมนูอาจจะมีการเปลี่ยนแปลงในแต่ละวัน
+              </span>
+              {/* <span className="inline-flex items-center rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/70 px-4 py-2 text-sm font-medium text-[var(--color-gold)] shadow">
+                ☕ เซตอาหารเช้า
+              </span> */}
+            </div>
+          </div>
+
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {products.length === 0 ? (
+              <div className="col-span-full rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/80 p-10 text-center text-[var(--color-text)]/80 shadow-lg shadow-black/40 backdrop-blur">
+                เมนูซาลาเปากำลังนึ่งอยู่ รอสักครู่นะคะ 🥟
               </div>
-            ))
-          )}
+            ) : (
+              products.map((p) => (
+                <div
+                  key={p._id}
+                  className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/75 shadow-lg shadow-black/40 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
+                >
+                  <div className="relative overflow-hidden">
+                    <div className="aspect-square w-full bg-[radial-gradient(circle_at_30%_30%,rgba(240,200,105,0.25),rgba(58,16,16,0.65))] flex items-center justify-center">
+                      {p.images?.[0] ? (
+                        <img
+                          src={p.images[0]}
+                          alt={p.title}
+                          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                        />
+                      ) : (
+                        <span className="text-4xl">🥟</span>
+                      )}
+                    </div>
+                    <div className="absolute top-4 left-4 rounded-full border border-[var(--color-rose)]/40 bg-[var(--color-burgundy)]/80 px-3 py-1 text-xs font-semibold text-[var(--color-rose)] shadow">
+                      เมนูแนะนำ
+                    </div>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-3 p-6">
+                    <div>
+                      <h3 className="text-xl font-semibold text-[var(--color-rose)]">
+                        {p.title}
+                      </h3>
+                      <p className="mt-1 text-sm text-[var(--color-text)]/70 line-clamp-3">
+                        {p.description}
+                      </p>
+                    </div>
+                    <div className="mt-auto flex items-center justify-between pt-2">
+                      <span className="text-lg font-bold text-[var(--color-gold)]">
+                        ฿{p.price}
+                      </span>
+                      <AddToCartButton product={p} />
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
         </div>
       </section>
 
-      <section className="bg-white/70">
-        <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-16 grid gap-10 md:grid-cols-3">
+      <section className="relative overflow-hidden py-16">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_25%,rgba(240,200,105,0.1),transparent_55%),radial-gradient(circle_at_85%_15%,rgba(193,138,29,0.2),transparent_60%),linear-gradient(160deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+        <div className="relative mx-auto grid max-w-screen-xl gap-10 px-6 py-10 text-[var(--color-text)] md:grid-cols-3 lg:px-8">
           {["ทำสดใหม่ทุกวัน", "ทำเองทุกขั้นตอน", "เลือกวัตถุดิบคุณภาพ"].map(
             (title, idx) => (
               <div
                 key={title}
-                className="rounded-3xl bg-white p-8 shadow-md shadow-[rgba(240,200,105,0.08)]"
+                className="rounded-3xl border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/75 p-8 shadow-lg shadow-black/30 backdrop-blur"
               >
                 {/* <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[var(--color-rose)] to-[var(--color-gold)] text-white text-xl shadow">
                   {idx === 0 ? "👩‍🍳" : idx === 1 ? "👐" : "🌾"}
                 </div> */}
-                <h3 className="mt-6 text-xl font-semibold text-[var(--color-choco)]">
+                <h3 className="text-xl font-semibold text-[var(--color-rose)]">
                   {title}
                 </h3>
-                <p className="mt-3 text-sm text-[var(--color-choco)]/70">
+                <p className="mt-3 text-sm text-[var(--color-text)]/75">
                   {idx === 0
                     ? "ขนมทุกชิ้นสดใหม่จากเตา ดูแลเองทุกวันเพื่อให้ได้รสชาติที่ดีที่สุด"
                     : idx === 1
@@ -194,6 +198,7 @@ export default async function HomePage() {
           )}
         </div>
       </section>
+
     </main>
   );
 }

--- a/app/(site)/preorder/page.jsx
+++ b/app/(site)/preorder/page.jsx
@@ -83,7 +83,7 @@ export default function PreOrderPage() {
               ไม่ว่าจะเป็นงานวันเกิด งานหมั้น งานองค์กร หรือของฝากพิเศษ ทีมเชฟของเราพร้อมช่วยออกแบบเมนูตามความต้องการ พร้อมที่ปรึกษาด้านรสชาติและงบประมาณ
             </p>
             <div className="grid gap-4 sm:grid-cols-2 text-sm text-[var(--color-choco)]/70">
-              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[#f5a25d15]">
+              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[rgba(240,200,105,0.08)]">
                 <p className="font-semibold text-[var(--color-choco)]">บริการที่ได้รับ</p>
                 <ul className="mt-3 space-y-2 list-disc list-inside">
                   <li>ออกแบบรสชาติและหน้าตาขนม</li>
@@ -91,7 +91,7 @@ export default function PreOrderPage() {
                   <li>จัดส่งและจัดเซตในสถานที่</li>
                 </ul>
               </div>
-              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[#f5a25d15]">
+              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[rgba(240,200,105,0.08)]">
                 <p className="font-semibold text-[var(--color-choco)]">ระยะเวลาแนะนำ</p>
                 <ul className="mt-3 space-y-2 list-disc list-inside">
                   <li>แจ้งล่วงหน้าอย่างน้อย 3-5 วัน</li>
@@ -102,7 +102,7 @@ export default function PreOrderPage() {
             </div>
           </div>
           <div className="flex-1">
-            <div className="rounded-[46%] bg-gradient-to-br from-white via-[#fff2e2] to-[#ffe8d2] p-10 shadow-2xl shadow-[#f5a25d25] text-center">
+            <div className="rounded-[46%] bg-gradient-to-br from-white via-[#fff2e2] to-[#ffe8d2] p-10 shadow-2xl shadow-[rgba(240,200,105,0.25)] text-center">
               <p className="text-sm font-semibold tracking-[0.3em] uppercase text-[var(--color-rose)]">Made to Order</p>
               <p className="mt-3 text-3xl font-black text-[var(--color-choco)]">Pre-order ขนมชิ้นโปรด</p>
               <p className="mt-4 text-sm text-[var(--color-choco)]/70">
@@ -116,7 +116,7 @@ export default function PreOrderPage() {
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 pb-20 grid gap-8 lg:grid-cols-[2fr_1fr]">
         <form
           onSubmit={handleSubmit}
-          className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[#f5a25d15] space-y-6"
+          className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[rgba(240,200,105,0.08)] space-y-6"
         >
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-choco)]">กรอกรายละเอียดสำหรับสั่งทำพิเศษ</h2>
@@ -259,14 +259,14 @@ export default function PreOrderPage() {
             <button
               type="submit"
               disabled={submitting}
-              className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอออกแบบเมนู"}
             </button>
           </div>
         </form>
 
-        <aside className="rounded-3xl bg-white/80 p-8 shadow-xl shadow-[#f5a25d15] space-y-6">
+        <aside className="rounded-3xl bg-white/80 p-8 shadow-xl shadow-[rgba(240,200,105,0.08)] space-y-6">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-choco)]">ปรึกษาฟรี</h2>
             <p className="mt-2 text-sm text-[var(--color-choco)]/70">
@@ -307,7 +307,7 @@ export default function PreOrderPage() {
               </div>
             </a>
           </div>
-          <div className="rounded-3xl bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] px-5 py-6 text-white shadow-lg shadow-[#f5a25d33]">
+          <div className="rounded-3xl bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-5 py-6 text-white shadow-lg shadow-[rgba(240,200,105,0.33)]">
             <p className="text-sm font-semibold uppercase tracking-[0.2em]">Tip</p>
             <p className="mt-2 text-sm">
               หากมี moodboard หรือรูปตัวอย่างที่ชื่นชอบ สามารถแนบส่งผ่านอีเมลหรือ LINE หลังจากกรอกแบบฟอร์มเพื่อให้ทีมออกแบบได้แม่นยำขึ้น

--- a/app/(site)/preorder/page.jsx
+++ b/app/(site)/preorder/page.jsx
@@ -68,12 +68,15 @@ export default function PreOrderPage() {
 
   return (
     <div className="relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-[#fff0e1] via-[#fff8ef] to-white" aria-hidden />
+      <div
+        className="absolute inset-0 bg-gradient-to-b from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.9)] to-[var(--color-burgundy)]"
+        aria-hidden
+      />
 
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 pt-16 pb-10 space-y-8">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
           <div className="flex-1 space-y-4">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-1 text-sm font-semibold text-[var(--color-rose-dark)] shadow">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy)]/70 px-4 py-1 text-sm font-semibold text-[var(--color-rose)] shadow-lg shadow-black/40">
               สั่งทำขนมพิเศษ
             </span>
             <h1 className="text-4xl sm:text-5xl font-extrabold text-[var(--color-choco)] leading-tight">
@@ -83,7 +86,7 @@ export default function PreOrderPage() {
               ไม่ว่าจะเป็นงานวันเกิด งานหมั้น งานองค์กร หรือของฝากพิเศษ ทีมเชฟของเราพร้อมช่วยออกแบบเมนูตามความต้องการ พร้อมที่ปรึกษาด้านรสชาติและงบประมาณ
             </p>
             <div className="grid gap-4 sm:grid-cols-2 text-sm text-[var(--color-choco)]/70">
-              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[rgba(240,200,105,0.08)]">
+              <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-5 shadow-2xl shadow-black/40 backdrop-blur">
                 <p className="font-semibold text-[var(--color-choco)]">บริการที่ได้รับ</p>
                 <ul className="mt-3 space-y-2 list-disc list-inside">
                   <li>ออกแบบรสชาติและหน้าตาขนม</li>
@@ -91,7 +94,7 @@ export default function PreOrderPage() {
                   <li>จัดส่งและจัดเซตในสถานที่</li>
                 </ul>
               </div>
-              <div className="rounded-3xl bg-white/90 p-5 shadow-md shadow-[rgba(240,200,105,0.08)]">
+              <div className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-5 shadow-2xl shadow-black/40 backdrop-blur">
                 <p className="font-semibold text-[var(--color-choco)]">ระยะเวลาแนะนำ</p>
                 <ul className="mt-3 space-y-2 list-disc list-inside">
                   <li>แจ้งล่วงหน้าอย่างน้อย 3-5 วัน</li>
@@ -102,7 +105,7 @@ export default function PreOrderPage() {
             </div>
           </div>
           <div className="flex-1">
-            <div className="rounded-[46%] bg-gradient-to-br from-white via-[#fff2e2] to-[#ffe8d2] p-10 shadow-2xl shadow-[rgba(240,200,105,0.25)] text-center">
+            <div className="rounded-[46%] border border-[var(--color-rose)]/30 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.85)] to-[var(--color-burgundy)] p-10 text-center shadow-2xl shadow-black/45">
               <p className="text-sm font-semibold tracking-[0.3em] uppercase text-[var(--color-rose)]">Made to Order</p>
               <p className="mt-3 text-3xl font-black text-[var(--color-choco)]">Pre-order ขนมชิ้นโปรด</p>
               <p className="mt-4 text-sm text-[var(--color-choco)]/70">
@@ -116,7 +119,7 @@ export default function PreOrderPage() {
       <section className="relative max-w-screen-xl mx-auto px-6 lg:px-10 pb-20 grid gap-8 lg:grid-cols-[2fr_1fr]">
         <form
           onSubmit={handleSubmit}
-          className="rounded-3xl bg-white/90 p-8 shadow-xl shadow-[rgba(240,200,105,0.08)] space-y-6"
+          className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/60 p-8 shadow-2xl shadow-black/45 backdrop-blur space-y-6"
         >
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-choco)]">กรอกรายละเอียดสำหรับสั่งทำพิเศษ</h2>
@@ -129,8 +132,8 @@ export default function PreOrderPage() {
             <div
               className={`rounded-2xl px-4 py-3 text-sm font-medium ${
                 status.type === "success"
-                  ? "bg-emerald-50 text-emerald-700"
-                  : "bg-rose-50 text-[var(--color-rose-dark)]"
+                  ? "border border-[var(--color-rose)]/35 bg-[rgba(240,200,105,0.12)] text-[var(--color-gold)]"
+                  : "border border-[var(--color-rose)]/40 bg-[rgba(120,32,32,0.55)] text-[var(--color-rose)]"
               }`}
             >
               {status.message}
@@ -138,44 +141,44 @@ export default function PreOrderPage() {
           )}
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               ชื่อ-นามสกุล*
               <input
                 type="text"
                 value={form.name}
                 onChange={updateField("name")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                 placeholder="ชื่อผู้ติดต่อ"
                 required
               />
             </label>
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               เบอร์ติดต่อ*
               <input
                 type="tel"
                 value={form.phone}
                 onChange={updateField("phone")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                 placeholder="0X-XXX-XXXX"
                 required
               />
             </label>
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               อีเมล
               <input
                 type="email"
                 value={form.email}
                 onChange={updateField("email")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                 placeholder="name@example.com"
               />
             </label>
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               ช่องทางที่สะดวกให้ติดต่อกลับ
               <select
                 value={form.preferredContact}
                 onChange={updateField("preferredContact")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               >
                 <option value="phone">โทรศัพท์</option>
                 <option value="line">LINE</option>
@@ -185,38 +188,38 @@ export default function PreOrderPage() {
           </div>
 
           <div className="grid gap-4 sm:grid-cols-3">
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               วันที่จัดงาน
               <input
                 type="date"
                 value={form.eventDate}
                 onChange={updateField("eventDate")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               />
             </label>
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               เวลาโดยประมาณ
               <input
                 type="time"
                 value={form.eventTime}
                 onChange={updateField("eventTime")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               />
             </label>
-            <label className="flex flex-col text-sm font-medium gap-2">
+            <label className="flex flex-col gap-2 text-sm font-medium">
               จำนวนโดยประมาณ
               <input
                 type="number"
                 min="0"
                 value={form.servings}
                 onChange={updateField("servings")}
-                className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+                className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
                 placeholder="เช่น 50 ชิ้น"
               />
             </label>
           </div>
 
-          <label className="flex flex-col text-sm font-medium gap-2">
+          <label className="flex flex-col gap-2 text-sm font-medium">
             งบประมาณคร่าวๆ (บาท)
             <input
               type="number"
@@ -224,30 +227,30 @@ export default function PreOrderPage() {
               step="100"
               value={form.budget}
               onChange={updateField("budget")}
-              className="rounded-full border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+              className="rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               placeholder="ระบุช่วงงบประมาณ"
             />
           </label>
 
-          <label className="flex flex-col text-sm font-medium gap-2">
+          <label className="flex flex-col gap-2 text-sm font-medium">
             รายละเอียดขนมที่ต้องการ*
             <textarea
               value={form.flavourIdeas}
               onChange={updateField("flavourIdeas")}
               rows={4}
-              className="rounded-3xl border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+              className="rounded-3xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               placeholder="ระบุธีม รสชาติ รูปแบบ หรือไอเดียที่อยากได้"
               required
             />
           </label>
 
-          <label className="flex flex-col text-sm font-medium gap-2">
+          <label className="flex flex-col gap-2 text-sm font-medium">
             ข้อมูลเพิ่มเติมที่อยากให้เราทราบ
             <textarea
               value={form.notes}
               onChange={updateField("notes")}
               rows={3}
-              className="rounded-3xl border border-white/0 bg-[rgba(255,241,236,0.7)] px-4 py-3 text-[var(--color-choco)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]"
+              className="rounded-3xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/60 px-4 py-3 text-[var(--color-text)] shadow-inner focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
               placeholder="แจ้งอาการแพ้ อุปกรณ์ตกแต่งเพิ่มเติม หรือรูปแบบการจัดส่ง"
             />
           </label>
@@ -259,14 +262,14 @@ export default function PreOrderPage() {
             <button
               type="submit"
               disabled={submitting}
-              className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-8 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/45 transition hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอออกแบบเมนู"}
             </button>
           </div>
         </form>
 
-        <aside className="rounded-3xl bg-white/80 p-8 shadow-xl shadow-[rgba(240,200,105,0.08)] space-y-6">
+        <aside className="rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/55 p-8 shadow-2xl shadow-black/45 backdrop-blur space-y-6">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-choco)]">ปรึกษาฟรี</h2>
             <p className="mt-2 text-sm text-[var(--color-choco)]/70">
@@ -276,7 +279,7 @@ export default function PreOrderPage() {
           <div className="space-y-4 text-sm text-[var(--color-choco)]/80">
             <a
               href="tel:021234567"
-              className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow hover:shadow-md transition"
+              className="flex items-center gap-3 rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/45 px-4 py-3 shadow-lg shadow-black/40 transition hover:shadow-xl"
             >
               <span className="text-xl">📞</span>
               <div>
@@ -288,7 +291,7 @@ export default function PreOrderPage() {
               href="https://line.me/ti/p/@sweetcravings"
               target="_blank"
               rel="noreferrer"
-              className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow hover:shadow-md transition"
+              className="flex items-center gap-3 rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/45 px-4 py-3 shadow-lg shadow-black/40 transition hover:shadow-xl"
             >
               <span className="text-xl">💬</span>
               <div>
@@ -298,7 +301,7 @@ export default function PreOrderPage() {
             </a>
             <a
               href="mailto:hello@sweetcravings.co"
-              className="flex items-center gap-3 rounded-2xl bg-white px-4 py-3 shadow hover:shadow-md transition"
+              className="flex items-center gap-3 rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/45 px-4 py-3 shadow-lg shadow-black/40 transition hover:shadow-xl"
             >
               <span className="text-xl">📧</span>
               <div>

--- a/app/(site)/register/page.js
+++ b/app/(site)/register/page.js
@@ -81,7 +81,7 @@ export default function RegisterPage() {
           </form>
 
           {msg && (
-            <p className={`mt-4 text-sm ${msg.includes("เสร็จ") ? "text-emerald-600" : "text-rose-600"}`}>
+            <p className={`mt-4 text-sm ${msg.includes("เสร็จ") ? "text-[var(--color-gold)]" : "text-[var(--color-rose)]"}`}>
               {String(msg)}
             </p>
           )}

--- a/app/(site)/register/page.js
+++ b/app/(site)/register/page.js
@@ -28,15 +28,15 @@ export default function RegisterPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[#ffe1d0] via-[#fff7f0] to-[#ffe1f5]" />
-      <div className="absolute -top-24 left-16 h-64 w-64 rounded-full bg-[#f5a25d]/20 blur-3xl" />
-      <div className="absolute -bottom-28 right-12 h-72 w-72 rounded-full bg-[#f3d36b]/25 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[#3a1010]" />
+      <div className="absolute -top-24 left-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
+      <div className="absolute -bottom-28 right-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
       <div className="relative flex items-center justify-center px-6 py-16">
-        <div className="w-full max-w-md rounded-3xl bg-white/95 p-8 shadow-2xl shadow-[#f5a25d20]">
+        <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/80 p-8 shadow-2xl shadow-black/50 backdrop-blur">
           <div className="text-center">
-            <h1 className="text-3xl font-bold text-[var(--color-rose-dark)]">สร้างบัญชีใหม่</h1>
-            <p className="mt-2 text-sm text-[var(--color-choco)]/70">
+            <h1 className="text-3xl font-bold text-[var(--color-rose)]">สร้างบัญชีใหม่</h1>
+            <p className="mt-2 text-sm text-[var(--color-text)]/70">
               สมัครสมาชิกเพื่อรับข่าวสาร โปรโมชั่น และสะสมคะแนนสำหรับลูกค้าประจำ
             </p>
           </div>
@@ -47,7 +47,7 @@ export default function RegisterPage() {
               <input
                 name="name"
                 placeholder="ชื่อเต็ม"
-                className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                 required
               />
             </div>
@@ -57,7 +57,7 @@ export default function RegisterPage() {
                 name="email"
                 type="email"
                 placeholder="name@example.com"
-                className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                 required
               />
             </div>
@@ -68,13 +68,13 @@ export default function RegisterPage() {
                 type="password"
                 placeholder="รหัสผ่าน"
                 minLength={6}
-                className="w-full rounded-2xl border border-[#f4c689]/60 bg-white px-4 py-3 text-sm text-[var(--color-choco)] focus:outline-none focus:ring-2 focus:ring-[#f5a25d]/30"
+                className="w-full rounded-2xl border border-[var(--color-rose)]/35 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-rose)]/30"
                 required
               />
             </div>
             <button
               disabled={loading}
-              className="w-full rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f3d36b] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition disabled:cursor-not-allowed disabled:opacity-70"
+              className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
             >
               {loading ? "กำลังสมัคร..." : "สมัครสมาชิก"}
             </button>
@@ -86,7 +86,7 @@ export default function RegisterPage() {
             </p>
           )}
 
-          <p className="mt-6 text-center text-sm text-[var(--color-choco)]/70">
+          <p className="mt-6 text-center text-sm text-[var(--color-text)]/70">
             มีบัญชีอยู่แล้ว?
             <Link href="/login" className="ml-2 font-semibold text-[var(--color-rose)] hover:text-[var(--color-rose-dark)]">
               เข้าสู่ระบบ

--- a/app/admin/coupons/page.jsx
+++ b/app/admin/coupons/page.jsx
@@ -2,15 +2,78 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+/* ---------- Shared UI (match Products page) ---------- */
+function StatBubble({ label, value, color }) {
+  const colorConfig = {
+    blue: { bg: "bg-[#E6F3FF]/60", border: "border-[#87CEEB]/40", accent: "bg-[#87CEEB]/20" },
+    green: { bg: "bg-[#F0F8E6]/60", border: "border-[#98FB98]/40", accent: "bg-[#98FB98]/20" },
+    orange: { bg: "bg-[#FFF8E1]/60", border: "border-[#FFB74D]/40", accent: "bg-[#FFB74D]/20" },
+    purple: { bg: "bg-[#F5F0FF]/60", border: "border-[#DDA0DD]/40", accent: "bg-[#DDA0DD]/20" },
+  };
+  const config = colorConfig[color] || colorConfig.blue;
+  return (
+    <div className={`relative overflow-hidden rounded-[1.5rem] border ${config.border} ${config.bg} p-4 shadow-sm hover:shadow-md transition-shadow backdrop-blur`}>
+      <div className={`absolute -right-4 -top-4 h-16 w-16 rounded-full ${config.accent}`} />
+      <div className="relative">
+        <p className="text-xs uppercase tracking-wide text-[#8B4513]/60 font-semibold">{label}</p>
+        <p className="mt-2 text-xl font-bold text-[#8B4513]">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, required, children }) {
+  return (
+    <label className="block text-sm font-medium text-[#8B4513]/80">
+      <span className="mb-2 block">
+        {label}
+        {required ? <span className="ml-1 text-red-500">*</span> : null}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+// Same sliding toggle as Products page
+function SlidingToggle({ isActive, onToggle, disabled = false }) {
+  return (
+    <button
+      onClick={onToggle}
+      disabled={disabled}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-[#D2691E] focus:ring-offset-2 ${
+        isActive ? "bg-[#228B22]" : "bg-gray-300"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+      title={isActive ? "คลิกเพื่อปิดการใช้งาน" : "คลิกเพื่อเปิดใช้งาน"}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white shadow-lg transition-transform duration-300 ${
+          isActive ? "translate-x-7" : "translate-x-1"
+        }`}
+      >
+        <span className="flex h-full w-full items-center justify-center text-xs">
+          {isActive ? "✓" : "✕"}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+/* ---------- Helpers ---------- */
 const emptyCoupon = {
   code: "",
-  type: "percent",
+  type: "percent", // percent | amount
   value: 10,
   minSubtotal: 0,
   expiresAt: "",
   active: true,
 };
 
+function formatCurrency(value) {
+  const amount = Number(value || 0);
+  return `฿${amount.toLocaleString("th-TH", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/* ---------- Page ---------- */
 export default function AdminCouponsPage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -44,15 +107,15 @@ export default function AdminCouponsPage() {
     setForm(emptyCoupon);
   }
 
-  function startEdit(coupon) {
-    setEditing(coupon);
+  function startEdit(c) {
+    setEditing(c);
     setForm({
-      code: coupon.code || "",
-      type: coupon.type || "percent",
-      value: Number(coupon.value || 0),
-      minSubtotal: Number(coupon.minSubtotal || 0),
-      expiresAt: coupon.expiresAt ? new Date(coupon.expiresAt).toISOString().slice(0, 16) : "",
-      active: !!coupon.active,
+      code: c.code || "",
+      type: c.type || "percent",
+      value: Number(c.value || 0),
+      minSubtotal: Number(c.minSubtotal || 0),
+      expiresAt: c.expiresAt ? new Date(c.expiresAt).toISOString().slice(0, 16) : "",
+      active: !!c.active,
     });
   }
 
@@ -62,7 +125,7 @@ export default function AdminCouponsPage() {
     setSaving(true);
 
     const payload = {
-      code: form.code,
+      code: form.code.trim().toUpperCase(),
       type: form.type,
       value: Number(form.value || 0),
       minSubtotal: Number(form.minSubtotal || 0),
@@ -72,6 +135,7 @@ export default function AdminCouponsPage() {
 
     const url = editing?._id ? `/api/coupons/${editing._id}` : "/api/coupons";
     const method = editing?._id ? "PATCH" : "POST";
+
     const res = await fetch(url, {
       method,
       headers: { "Content-Type": "application/json" },
@@ -87,20 +151,6 @@ export default function AdminCouponsPage() {
     await load();
   }
 
-  async function toggleActive(coupon) {
-    const res = await fetch(`/api/coupons/${coupon._id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ active: !coupon.active }),
-    });
-    const data = await res.json();
-    if (!res.ok) {
-      alert(data?.error || "Update failed");
-      return;
-    }
-    setItems((prev) => prev.map((c) => (c._id === coupon._id ? { ...c, active: !coupon.active } : c)));
-  }
-
   async function onDelete(coupon) {
     if (!confirm(`ลบคูปอง "${coupon.code}" ?`)) return;
     const res = await fetch(`/api/coupons/${coupon._id}`, { method: "DELETE" });
@@ -112,36 +162,59 @@ export default function AdminCouponsPage() {
     await load();
   }
 
+  async function toggleActive(coupon) {
+    const newValue = !coupon.active;
+    const res = await fetch(`/api/coupons/${coupon._id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ active: newValue }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data?.error || "Update failed");
+      return;
+    }
+    setItems((prev) => prev.map((c) => (c._id === coupon._id ? { ...c, active: newValue } : c)));
+  }
+
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase();
     if (!term) return items;
-    return items.filter((coupon) => `${coupon.code} ${coupon.type}`.toLowerCase().includes(term));
+    return items.filter((c) =>
+      `${c.code} ${c.type} ${c.value} ${c.minSubtotal}`.toLowerCase().includes(term)
+    );
   }, [items, search]);
 
-  const activeCount = filtered.filter((coupon) => coupon.active).length;
-  const percentCount = filtered.filter((coupon) => coupon.type === "percent").length;
-  const amountCount = filtered.filter((coupon) => coupon.type === "amount").length;
+  const activeCount = filtered.filter((c) => c.active).length;
+  const percentCount = filtered.filter((c) => c.type === "percent").length;
+  const amountCount = filtered.filter((c) => c.type === "amount").length;
 
   return (
-    <main className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <main className="space-y-8">
+      {/* Header Section (match products) */}
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 p-8 shadow-xl shadow-[rgba(139,69,19,0.2)] backdrop-blur">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">คูปองและโปรโมชัน</h2>
-            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
-              สร้างข้อเสนอพิเศษเพื่อดึงดูดลูกค้า และกำหนดเงื่อนไขให้ตรงกับกลยุทธ์การขาย
+            <h2 className="text-2xl font-bold text-[#8B4513]">จัดการคูปอง</h2>
+            <p className="mt-1 text-[#8B4513]/70">
+              สร้าง/แก้ไข และเปิดปิดการใช้งานคูปองให้ตรงกับกลยุทธ์การขาย
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <input
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="ค้นหาคูปอง"
-              className="w-52 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
-            />
+            <div className="relative">
+              <input
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="ค้นหาโค้ด ประเภท หรือมูลค่า"
+                className="w-60 rounded-full border border-[#D2691E]/30 bg-white/70 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
+              />
+              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-[#8B4513]/50">
+                🔍
+              </span>
+            </div>
             <button
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
+              className="inline-flex items-center gap-2 rounded-full bg-[#D2691E] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(139,69,19,0.25)] transition hover:bg-[#8B4513]"
               onClick={startCreate}
             >
               🎉 สร้างคูปองใหม่
@@ -149,185 +222,267 @@ export default function AdminCouponsPage() {
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <CouponStat label="คูปองทั้งหมด" value={filtered.length} />
-          <CouponStat label="เปิดใช้งาน" value={activeCount} tone="from-[#7cd1b8]/30" />
-          <CouponStat label="ส่วนลด %" value={percentCount} tone="from-[#f3d36b]/30" />
-          <CouponStat label="ส่วนลดเป็นจำนวน" value={amountCount} tone="from-[#f7c68b]/30" />
+        {/* Stats (use StatBubble like products) */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatBubble label="คูปองทั้งหมด" value={filtered.length} color="blue" />
+          <StatBubble label="เปิดใช้งาน" value={activeCount} color="green" />
+          <StatBubble label="ส่วนลด %" value={percentCount} color="orange" />
+          <StatBubble label="ส่วนลดจำนวนเงิน" value={amountCount} color="purple" />
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
+      {/* Table/Card Section (match products) */}
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur overflow-hidden">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการคูปอง</h3>
-            <p className="text-xs text-[var(--color-choco)]/60">เปิด/ปิดการใช้งานและแก้ไขเงื่อนไขได้ทุกเมื่อ</p>
+            <h3 className="text-lg font-bold text-[#8B4513]">รายการคูปอง</h3>
+            <p className="text-xs text-[#8B4513]/60">แก้ไขเงื่อนไขและเปิด/ปิดการใช้งานได้ทันที</p>
           </div>
-          <span className="text-xs font-medium uppercase tracking-wide text-[var(--color-choco)]/50">
-            {filtered.length} รายการ
+          <span className="text-xs font-medium uppercase tracking-wide text-[#8B4513]/50">
+            {filtered.length} รายการที่แสดง
           </span>
         </header>
 
-        {loading && <p className="px-6 py-6 text-sm text-[var(--color-choco)]/70">กำลังโหลดข้อมูล...</p>}
-        {err && !loading && <p className="px-6 py-6 text-sm text-rose-600">{err}</p>}
+        {loading && (
+          <div className="flex items-center justify-center px-6 py-8">
+            <div className="flex items-center gap-3">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-[#D2691E] border-t-transparent"></div>
+              <span className="text-sm text-[#8B4513]/70">กำลังโหลดข้อมูลคูปอง...</span>
+            </div>
+          </div>
+        )}
+
+        {err && !loading && (
+          <div className="flex items-center justify-center px-6 py-8">
+            <div className="rounded-[1.5rem] bg-red-50 border border-red-200 px-6 py-4 text-center">
+              <span className="text-2xl mb-2 block">⚠️</span>
+              <span className="text-sm text-red-600">{err}</span>
+            </div>
+          </div>
+        )}
 
         {!loading && !err && (
-          <div className="overflow-x-auto">
-            <table className="min-w-full border-separate border-spacing-y-2 px-4 py-4 text-sm">
-              <thead>
-                <tr className="text-left text-xs uppercase tracking-wide text-[var(--color-choco)]/50">
-                  <th className="px-4 py-2">โค้ด</th>
-                  <th className="px-4 py-2">ประเภท</th>
-                  <th className="px-4 py-2">มูลค่า</th>
-                  <th className="px-4 py-2">ขั้นต่ำ</th>
-                  <th className="px-4 py-2">หมดอายุ</th>
-                  <th className="px-4 py-2">สถานะ</th>
-                  <th className="px-4 py-2 text-right">จัดการ</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((coupon) => (
-                  <tr key={coupon._id} className="rounded-3xl bg-white/80 shadow shadow-[rgba(240,200,105,0.07)]">
-                    <td className="px-4 py-4 font-semibold text-[var(--color-choco)]">{coupon.code}</td>
-                    <td className="px-4 py-4 text-[var(--color-choco)]/70">{coupon.type}</td>
-                    <td className="px-4 py-4 text-[var(--color-choco)]">
-                      {coupon.type === "percent" ? `${coupon.value}%` : formatCurrency(coupon.value)}
-                    </td>
-                    <td className="px-4 py-4 text-[var(--color-choco)]">{formatCurrency(coupon.minSubtotal)}</td>
-                    <td className="px-4 py-4 text-xs text-[var(--color-choco)]/60">
-                      {coupon.expiresAt ? new Date(coupon.expiresAt).toLocaleString("th-TH") : "ไม่มีกำหนด"}
-                    </td>
-                    <td className="px-4 py-4">
-                      <button
-                        onClick={() => toggleActive(coupon)}
-                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition ${
-                          coupon.active
-                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
-                            : "bg-gray-200 text-gray-500"
+          <div className="overflow-hidden">
+            {/* Mobile Cards */}
+            <div className="block lg:hidden p-4 space-y-4">
+              {filtered.length === 0 ? (
+                <div className="text-center py-8">
+                  <span className="text-4xl mb-4 block">🎟️</span>
+                  <span className="text-[#8B4513]/60">ไม่พบคูปองที่ตรงกับคำค้นหา</span>
+                </div>
+              ) : (
+                filtered.map((c) => (
+                  <div key={c._id} className="rounded-[1.5rem] bg-white/90 border border-white/60 p-4 shadow-sm">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <h4 className="font-semibold text-[#8B4513] truncate">{c.code}</h4>
+                        <p className="text-xs text-[#8B4513]/50">
+                          {c.type === "percent" ? `ส่วนลด ${c.value}%` : `ส่วนลด ${formatCurrency(c.value)}`}
+                        </p>
+                        <div className="mt-2 text-sm text-[#8B4513]/80">
+                          ขั้นต่ำ: {formatCurrency(c.minSubtotal)}
+                        </div>
+                        <div className="text-xs text-[#8B4513]/60 mt-1">
+                          หมดอายุ: {c.expiresAt ? new Date(c.expiresAt).toLocaleString("th-TH") : "ไม่มีกำหนด"}
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <div className="flex items-center gap-2">
+                          <SlidingToggle isActive={c.active} onToggle={() => toggleActive(c)} />
+                          <span className="text-xs text-[#8B4513]/70">{c.active ? "ใช้งานอยู่" : "ปิดใช้งาน"}</span>
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            className="rounded-full border border-[#D2691E]/30 px-3 py-1 text-xs font-semibold text-[#D2691E] transition hover:bg-[#D2691E]/10"
+                            onClick={() => startEdit(c)}
+                          >
+                            แก้ไข
+                          </button>
+                          <button
+                            className="rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-500 transition hover:bg-red-50"
+                            onClick={() => onDelete(c)}
+                          >
+                            ลบ
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Desktop Table */}
+            <div className="hidden lg:block overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="bg-[#F5DEB3]/30 border-b border-white/40">
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">โค้ด</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">ประเภท</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">มูลค่า</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">ขั้นต่ำ</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">หมดอายุ</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">สถานะ</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#8B4513]">จัดการ</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/40">
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="px-6 py-12 text-center">
+                        <div className="flex flex-col items-center">
+                          <span className="text-4xl mb-4">🎟️</span>
+                          <span className="text-[#8B4513]/60">ไม่พบคูปองที่ตรงกับคำค้นหา</span>
+                        </div>
+                      </td>
+                    </tr>
+                  ) : (
+                    filtered.map((c, idx) => (
+                      <tr
+                        key={c._id}
+                        className={`transition-colors hover:bg-white/70 ${
+                          idx % 2 === 0 ? "bg-white/50" : "bg-[#FFF8DC]/30"
                         }`}
                       >
-                        <span className="text-base">{coupon.active ? "💡" : "🌙"}</span>
-                        {coupon.active ? "ใช้งานอยู่" : "ปิดการใช้งาน"}
-                      </button>
-                    </td>
-                    <td className="px-4 py-4 text-right">
-                      <div className="flex justify-end gap-2">
-                        <button
-                          className="rounded-full border border-[var(--color-rose)]/40 px-4 py-1 text-xs font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-[var(--color-rose)]/10"
-                          onClick={() => startEdit(coupon)}
-                        >
-                          แก้ไข
-                        </button>
-                        <button
-                          className="rounded-full border border-rose-200 px-4 py-1 text-xs font-semibold text-rose-500 transition hover:border-rose-400 hover:bg-rose-100"
-                          onClick={() => onDelete(coupon)}
-                        >
-                          ลบ
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                        <td className="px-6 py-4 font-semibold text-[#8B4513]">{c.code}</td>
+                        <td className="px-6 py-4 text-[#8B4513]">{c.type}</td>
+                        <td className="px-6 py-4 text-[#8B4513]">
+                          {c.type === "percent" ? `${c.value}%` : formatCurrency(c.value)}
+                        </td>
+                        <td className="px-6 py-4 text-[#8B4513]">{formatCurrency(c.minSubtotal)}</td>
+                        <td className="px-6 py-4 text-xs text-[#8B4513]/70">
+                          {c.expiresAt ? new Date(c.expiresAt).toLocaleString("th-TH") : "ไม่มีกำหนด"}
+                        </td>
+                        <td className="px-6 py-4">
+                          <div className="flex items-center gap-3">
+                            <SlidingToggle isActive={c.active} onToggle={() => toggleActive(c)} />
+                            <span className="text-xs text-[#8B4513]/70">
+                              {c.active ? "ใช้งานอยู่" : "ปิดใช้งาน"}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 text-right">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              className="rounded-full border border-[#D2691E]/30 px-4 py-1 text-xs font-semibold text-[#D2691E] transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+                              onClick={() => startEdit(c)}
+                            >
+                              แก้ไข
+                            </button>
+                            <button
+                              className="rounded-full border border-red-200 px-4 py-1 text-xs font-semibold text-red-500 transition hover:border-red-400 hover:bg-red-50"
+                              onClick={() => onDelete(c)}
+                            >
+                              ลบ
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </section>
 
+      {/* Modal (match products) */}
       {editing !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
-          <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white/95 shadow-2xl shadow-[rgba(240,200,105,0.3)]">
-            <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
+          <div className="relative w-full max-w-3xl overflow-hidden rounded-[2rem] border border-white/80 bg-white/95 shadow-2xl shadow-[rgba(139,69,19,0.3)] backdrop-blur">
+            <div className="flex items-center justify-between border-b border-white/60 bg-[#F5DEB3]/20 px-6 py-4">
               <div>
-                <h3 className="text-lg font-semibold text-[var(--color-choco)]">
+                <h3 className="text-lg font-bold text-[#8B4513]">
                   {editing?._id ? "แก้ไขคูปอง" : "สร้างคูปองใหม่"}
                 </h3>
-                <p className="text-xs text-[var(--color-choco)]/60">
-                  เติมรายละเอียดเพื่อกำหนดสิทธิ์ให้ลูกค้าตามกลยุทธ์ของคุณ
+                <p className="text-xs text-[#8B4513]/60">
+                  กำหนดรายละเอียดและเงื่อนไขคูปองให้เหมาะกับแคมเปญของคุณ
                 </p>
               </div>
               <button
-                className="rounded-full border border-[var(--color-choco)]/10 bg-white px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/30 hover:text-[var(--color-choco)]"
+                className="rounded-full border border-[#8B4513]/20 bg-white px-3 py-1 text-xs font-semibold text-[#8B4513]/70 transition hover:border-[#8B4513]/30 hover:text-[#8B4513]"
                 onClick={() => setEditing(null)}
               >
                 ปิด
               </button>
             </div>
 
-            <form onSubmit={onSubmit} className="space-y-4 px-6 py-6">
-              <Field label="รหัสคูปอง" required>
-                <input
-                  className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
-                  value={form.code}
-                  onChange={(e) => setForm((f) => ({ ...f, code: e.target.value.toUpperCase() }))}
-                  required
-                />
-              </Field>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <Field label="ประเภทส่วนลด">
-                  <select
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
-                    value={form.type}
-                    onChange={(e) => setForm((f) => ({ ...f, type: e.target.value }))}
-                  >
-                    <option value="percent">เปอร์เซ็นต์ (%)</option>
-                    <option value="amount">จำนวนเงิน (บาท)</option>
-                  </select>
-                </Field>
-                <Field label="มูลค่าส่วนลด">
+            <form onSubmit={onSubmit} className="grid gap-6 px-6 py-6 md:grid-cols-[1.1fr_1fr]">
+              <div className="space-y-4">
+                <Field label="รหัสคูปอง" required>
                   <input
-                    type="number"
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
-                    value={form.value}
-                    onChange={(e) => setForm((f) => ({ ...f, value: Number(e.target.value || 0) }))}
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
+                    value={form.code}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, code: e.target.value.toUpperCase().replace(/\s+/g, "") }))
+                    }
+                    required
                   />
                 </Field>
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field label="ประเภทส่วนลด">
+                    <select
+                      className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
+                      value={form.type}
+                      onChange={(e) => setForm((f) => ({ ...f, type: e.target.value }))}
+                    >
+                      <option value="percent">เปอร์เซ็นต์ (%)</option>
+                      <option value="amount">จำนวนเงิน (บาท)</option>
+                    </select>
+                  </Field>
+                  <Field label="มูลค่าส่วนลด">
+                    <input
+                      type="number"
+                      className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
+                      value={form.value}
+                      onChange={(e) => setForm((f) => ({ ...f, value: Number(e.target.value || 0) }))}
+                    />
+                  </Field>
+                </div>
                 <Field label="ยอดสั่งซื้อขั้นต่ำ (บาท)">
                   <input
                     type="number"
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.minSubtotal}
                     onChange={(e) => setForm((f) => ({ ...f, minSubtotal: Number(e.target.value || 0) }))}
                   />
                 </Field>
+              </div>
+
+              <div className="space-y-4">
                 <Field label="วันหมดอายุ">
                   <input
                     type="datetime-local"
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.expiresAt}
                     onChange={(e) => setForm((f) => ({ ...f, expiresAt: e.target.value }))}
                   />
                 </Field>
-              </div>
 
-              <label className="flex items-center gap-3 text-sm font-medium text-[var(--color-choco)]/80">
-                <input
-                  type="checkbox"
-                  checked={form.active}
-                  onChange={(e) => setForm((f) => ({ ...f, active: e.target.checked }))}
-                  className="h-4 w-4 rounded border-[var(--color-rose)]/40 text-[var(--color-rose)] focus:ring-[var(--color-rose)]"
-                />
-                เปิดใช้งานคูปองทันที
-              </label>
+                <div className="flex items-center gap-3">
+                  <SlidingToggle
+                    isActive={form.active}
+                    onToggle={() => setForm((f) => ({ ...f, active: !f.active }))}
+                  />
+                  <label className="text-sm font-medium text-[#8B4513]/80">เปิดใช้งานคูปองทันที</label>
+                </div>
 
-              <div className="flex justify-end gap-3 pt-2">
-                <button
-                  type="button"
-                  className="rounded-full border border-[var(--color-choco)]/20 px-5 py-2 text-sm font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/40 hover:text-[var(--color-choco)]"
-                  onClick={() => setEditing(null)}
-                >
-                  ยกเลิก
-                </button>
-                <button
-                  className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
-                  disabled={saving}
-                >
-                  {saving ? "กำลังบันทึก..." : editing?._id ? "บันทึกการแก้ไข" : "สร้างคูปอง"}
-                </button>
+                <div className="flex flex-wrap justify-end gap-3 pt-4">
+                  <button
+                    type="button"
+                    className="rounded-full border border-[#8B4513]/20 px-5 py-2 text-sm font-semibold text-[#8B4513]/70 transition hover:border-[#8B4513]/40 hover:text-[#8B4513]"
+                    onClick={() => setEditing(null)}
+                  >
+                    ยกเลิก
+                  </button>
+                  <button
+                    className="inline-flex items-center gap-2 rounded-full bg-[#D2691E] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(139,69,19,0.25)] transition hover:bg-[#8B4513] disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={saving}
+                  >
+                    {saving ? "กำลังบันทึก..." : editing?._id ? "บันทึกการแก้ไข" : "สร้างคูปอง"}
+                  </button>
+                </div>
               </div>
             </form>
           </div>
@@ -335,36 +490,4 @@ export default function AdminCouponsPage() {
       )}
     </main>
   );
-}
-
-function Field({ label, required, children }) {
-  return (
-    <label className="block text-sm font-medium text-[var(--color-choco)]/80">
-      <span className="mb-2 block">
-        {label}
-        {required ? <span className="ml-1 text-rose-500">*</span> : null}
-      </span>
-      {children}
-    </label>
-  );
-}
-
-function CouponStat({ label, value, tone }) {
-  return (
-    <div className="relative overflow-hidden rounded-3xl border border-white/70 bg-white/80 p-4 text-sm font-semibold text-[var(--color-choco)] shadow-inner">
-      {tone ? <div className={`pointer-events-none absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br ${tone}`} /> : null}
-      <div className="relative">
-        <p className="text-xs uppercase tracking-wide text-[var(--color-choco)]/50">{label}</p>
-        <p className="mt-2 text-xl text-[var(--color-rose-dark)]">{value}</p>
-      </div>
-    </div>
-  );
-}
-
-function formatCurrency(value) {
-  const amount = Number(value || 0);
-  return `฿${amount.toLocaleString("th-TH", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
 }

--- a/app/admin/coupons/page.jsx
+++ b/app/admin/coupons/page.jsx
@@ -124,7 +124,7 @@ export default function AdminCouponsPage() {
 
   return (
     <main className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">คูปองและโปรโมชัน</h2>
@@ -141,7 +141,7 @@ export default function AdminCouponsPage() {
               className="w-52 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
             />
             <button
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)]"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
               onClick={startCreate}
             >
               🎉 สร้างคูปองใหม่
@@ -157,7 +157,7 @@ export default function AdminCouponsPage() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f5a25d18]">
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการคูปอง</h3>
@@ -187,7 +187,7 @@ export default function AdminCouponsPage() {
               </thead>
               <tbody>
                 {filtered.map((coupon) => (
-                  <tr key={coupon._id} className="rounded-3xl bg-white/80 shadow shadow-[#f5a25d12]">
+                  <tr key={coupon._id} className="rounded-3xl bg-white/80 shadow shadow-[rgba(240,200,105,0.07)]">
                     <td className="px-4 py-4 font-semibold text-[var(--color-choco)]">{coupon.code}</td>
                     <td className="px-4 py-4 text-[var(--color-choco)]/70">{coupon.type}</td>
                     <td className="px-4 py-4 text-[var(--color-choco)]">
@@ -236,7 +236,7 @@ export default function AdminCouponsPage() {
 
       {editing !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
-          <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white/95 shadow-2xl shadow-[#f5a25d30]">
+          <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white/95 shadow-2xl shadow-[rgba(240,200,105,0.3)]">
             <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
               <div>
                 <h3 className="text-lg font-semibold text-[var(--color-choco)]">
@@ -323,7 +323,7 @@ export default function AdminCouponsPage() {
                   ยกเลิก
                 </button>
                 <button
-                  className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
                   disabled={saving}
                 >
                   {saving ? "กำลังบันทึก..." : editing?._id ? "บันทึกการแก้ไข" : "สร้างคูปอง"}

--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -5,30 +5,30 @@ export const metadata = { title: "Admin | Sweet Cravings" };
 
 export default function AdminLayout({ children }) {
   return (
-    <div className="relative min-h-screen bg-[radial-gradient(circle_at_20%_20%,#ffe6f2,transparent_55%),radial-gradient(circle_at_80%_0%,#fff5e4,transparent_45%),radial-gradient(circle_at_100%_80%,#ffe9fb,transparent_35%)] text-[var(--color-choco)] lg:flex">
+    <div className="relative min-h-screen bg-[radial-gradient(circle_at_15%_20%,#4f1818,transparent_55%),radial-gradient(circle_at_80%_0%,#2b0c0c,transparent_50%),radial-gradient(circle_at_100%_80%,#180404,transparent_45%)] text-[var(--color-gold)] lg:flex">
       <AdminSidebar />
 
       <main className="flex-1 lg:ml-0">
-        <div className="sticky top-0 z-30 border-b border-white/60 bg-white/70 backdrop-blur-md">
+        <div className="sticky top-0 z-30 border-b border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/80 backdrop-blur-md">
           <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between lg:px-10">
             <div>
-              <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-choco)]/60">
+              <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-gold)]/60">
                 Sweet Cravings Admin
               </p>
-              <h1 className="mt-1 text-2xl font-semibold text-[var(--color-rose-dark)]">
+              <h1 className="mt-1 text-2xl font-semibold text-[var(--color-rose)]">
                 แผงควบคุมการจัดการร้าน
               </h1>
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <Link
                 href="/"
-                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-white"
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)]"
               >
                 🏬 กลับหน้าร้าน
               </Link>
               <Link
                 href="/orders"
-                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/40 transition hover:bg-[var(--color-rose-dark)]"
               >
                 🛒 ดูร้านแบบลูกค้า
               </Link>

--- a/app/admin/orders/page.jsx
+++ b/app/admin/orders/page.jsx
@@ -146,7 +146,7 @@ export default function AdminOrdersPage() {
 
   if (loading)
     return (
-      <main className="rounded-3xl border border-white/80 bg-white/80 px-6 py-10 text-[var(--color-choco)]/70 shadow-lg shadow-[#f5a25d14]">
+      <main className="rounded-3xl border border-white/80 bg-white/80 px-6 py-10 text-[var(--color-choco)]/70 shadow-lg shadow-[rgba(240,200,105,0.08)]">
         กำลังโหลดคำสั่งซื้อ...
       </main>
     );
@@ -160,7 +160,7 @@ export default function AdminOrdersPage() {
 
   return (
     <main className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">คำสั่งซื้อทั้งหมด</h2>
@@ -185,7 +185,7 @@ export default function AdminOrdersPage() {
             </label>
             <a
               href="/api/admin/export/orders"
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)]"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
             >
               ⬇️ ส่งออก CSV
             </a>
@@ -219,7 +219,7 @@ export default function AdminOrdersPage() {
             return (
               <article
                 key={order._id}
-                className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-xl shadow-[#f5a25d14] backdrop-blur"
+                className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-xl shadow-[rgba(240,200,105,0.08)] backdrop-blur"
               >
                 <header className="flex flex-col gap-3 border-b border-white/60 pb-4 md:flex-row md:items-center md:justify-between">
                   <div>
@@ -244,7 +244,7 @@ export default function AdminOrdersPage() {
                         className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition ${
                           !canAccept || isUpdating
                             ? "cursor-not-allowed bg-[var(--color-rose)]/20 text-[var(--color-choco)]/40"
-                            : "bg-[var(--color-rose)] text-white shadow shadow-[#f5a25d33] hover:bg-[var(--color-rose-dark)]"
+                            : "bg-[var(--color-rose)] text-white shadow shadow-[rgba(240,200,105,0.33)] hover:bg-[var(--color-rose-dark)]"
                         }`}
                         title={
                           canAccept
@@ -396,7 +396,7 @@ export default function AdminOrdersPage() {
           onClick={() => setSelectedSlip(null)}
         >
           <div
-            className="max-h-full w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white shadow-2xl shadow-[#f5a25d30]"
+            className="max-h-full w-full max-w-xl overflow-hidden rounded-3xl border border-white/70 bg-white shadow-2xl shadow-[rgba(240,200,105,0.3)]"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-5 py-3 text-sm font-semibold text-[var(--color-choco)]">

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -47,39 +47,46 @@ export default function AdminDashboardPage() {
 
   if (err)
     return (
-      <section className="rounded-3xl border border-rose-200/60 bg-rose-50/80 p-6 text-rose-700 shadow-sm">
-        {err}
+      <section className="rounded-[2rem] border border-red-200/60 bg-red-50/80 p-6 text-red-700 shadow-lg shadow-[rgba(139,69,19,0.15)]">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">⚠️</span>
+          <span>{err}</span>
+        </div>
       </section>
     );
   if (!data)
     return (
-      <section className="rounded-3xl border border-white/60 bg-white/70 p-6 text-[var(--color-choco)]/70 shadow-sm">
-        กำลังโหลดข้อมูลร้าน...
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 p-6 text-[#8B4513]/70 shadow-lg shadow-[rgba(139,69,19,0.15)] backdrop-blur">
+        <div className="flex items-center gap-3">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-[#D2691E] border-t-transparent"></div>
+          <span>กำลังโหลดข้อมูลร้าน...</span>
+        </div>
       </section>
     );
 
   const { cards, topProducts } = data;
 
   return (
-    <div className="space-y-12">
-      <section className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-[rgba(240,200,105,0.2)] backdrop-blur">
+    <div className="space-y-8">
+      {/* Header Section */}
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 p-8 shadow-xl shadow-[rgba(139,69,19,0.2)] backdrop-blur">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h2 className="text-3xl font-semibold text-[var(--color-rose-dark)]">
+            <h2 className="text-3xl font-bold text-[#8B4513]">
               ภาพรวมร้านวันนี้
             </h2>
-            <p className="mt-2 max-w-xl text-sm leading-relaxed text-[var(--color-choco)]/70">
+            <p className="mt-2 max-w-xl text-[#8B4513]/70 leading-relaxed">
               ตรวจสอบยอดขาย ออเดอร์ และสต็อกสินค้าในมุมมองเดียว เพื่อวางแผนการผลิตและบริการลูกค้าได้อย่างมั่นใจ
             </p>
           </div>
-          <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-choco)]/60">
+          <div className="flex flex-wrap gap-3">
             {statusChips.map((chip) => (
               <div
                 key={chip.key}
-                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 px-4 py-2"
+                className="inline-flex items-center gap-2 rounded-full bg-[#F5DEB3]/30 border border-[#D2691E]/30 px-4 py-2 shadow-sm"
               >
-                <span className="text-[var(--color-rose)]">{chip.label}</span>
-                <span className="text-[var(--color-choco)]">
+                <span className="text-sm font-medium text-[#D2691E]">{chip.label}</span>
+                <span className="text-sm font-semibold text-[#8B4513]">
                   {chip.prefix}
                   {cards[chip.key]}
                 </span>
@@ -88,70 +95,79 @@ export default function AdminDashboardPage() {
           </div>
         </div>
 
+        {/* Stats Cards */}
         <div className="mt-8 grid gap-6 md:grid-cols-3">
           <StatCard
             title="ยอดขายวันนี้"
             value={`฿${cards.todaySales}`}
             caption="เปรียบเทียบจากยอดรวมที่ยืนยันแล้ว"
-            accent="from-[#f3d36b]/80 via-[var(--color-rose-dark)]/40 to-transparent"
+            color="green"
+            icon="💰"
           />
           <StatCard
             title="ออเดอร์ใหม่"
             value={cards.newOrders}
             caption="ตรวจสอบรายละเอียดก่อน 18:00 น. เพื่อจัดส่งทันวันถัดไป"
-            accent="from-[var(--color-rose)]/60 via-[var(--color-gold)]/40 to-transparent"
+            color="blue"
+            icon="📦"
           />
           <StatCard
             title="สินค้าใกล้หมด"
             value={cards.lowStock}
             caption="เติมสต็อกล่วงหน้าเพื่อไม่ให้ยอดขายสะดุด"
-            accent="from-[#7cd1b8]/60 via-[var(--color-gold)]/40 to-transparent"
+            color="orange"
+            icon="📊"
           />
         </div>
       </section>
 
       <section className="grid gap-8 lg:grid-cols-3">
+        {/* Left Column */}
         <div className="lg:col-span-2 space-y-6">
-          <div className="rounded-3xl border border-[var(--color-rose)]/30 bg-[rgba(240,200,105,0.12)]/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
+          {/* Top Products Table */}
+          <div className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h3 className="text-xl font-semibold text-[var(--color-choco)]">
+                <h3 className="text-xl font-bold text-[#8B4513]">
                   สินค้าที่ขายดีที่สุดประจำเดือน
                 </h3>
-                <p className="text-sm text-[var(--color-choco)]/60">
+                <p className="text-[#8B4513]/70 mt-1">
                   ข้อมูลอัปเดตรายวัน พร้อมดาวน์โหลดไฟล์เพื่อวิเคราะห์ต่อ
                 </p>
               </div>
               <a
                 href="/api/admin/export/sales"
-                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center gap-2 rounded-full bg-[#D2691E] px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-[rgba(139,69,19,0.25)] transition hover:bg-[#8B4513]"
               >
                 ⬇️ ดาวน์โหลด CSV
               </a>
             </div>
 
-            <div className="mt-6 overflow-hidden rounded-2xl border border-white/60 bg-white/70">
-              <table className="w-full text-sm text-[var(--color-choco)]/80">
-                <thead className="bg-[#fff5e4] text-[var(--color-choco)]/80">
+            <div className="mt-6 overflow-hidden rounded-[1.5rem] border border-white/60 bg-white/50 shadow-inner">
+              <table className="w-full text-sm">
+                <thead className="bg-[#F5DEB3]/50 border-b border-white/60">
                   <tr>
-                    <th className="px-4 py-3 text-left font-medium">สินค้า</th>
-                    <th className="px-4 py-3 text-right font-medium">จำนวนที่ขาย</th>
-                    <th className="px-4 py-3 text-right font-medium">รายได้ (฿)</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">สินค้า</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#8B4513]">จำนวนที่ขาย</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#8B4513]">รายได้ (฿)</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody className="divide-y divide-white/40">
                   {topProducts.length === 0 ? (
                     <tr>
-                      <td colSpan={3} className="px-4 py-6 text-center text-sm text-[var(--color-choco)]/60">
-                        ยังไม่มีข้อมูลยอดขายสำหรับช่วงเวลานี้
+                      <td colSpan={3} className="px-6 py-8 text-center">
+                        <div className="flex flex-col items-center">
+                          <span className="text-4xl mb-2">📈</span>
+                          <span className="text-[#8B4513]/60">ยังไม่มีข้อมูลยอดขายสำหรับช่วงเวลานี้</span>
+                        </div>
                       </td>
                     </tr>
                   ) : (
                     topProducts.map((p, idx) => (
-                      <tr key={p._id} className={idx % 2 === 0 ? "bg-white" : "bg-[#fff7f0]"}>
-                        <td className="px-4 py-3 font-medium">{p._id}</td>
-                        <td className="px-4 py-3 text-right">{p.qty}</td>
-                        <td className="px-4 py-3 text-right">{p.revenue}</td>
+                      <tr key={p._id} className="hover:bg-white/70 transition-colors">
+                        <td className="px-6 py-4 font-medium text-[#8B4513]">{p._id}</td>
+                        <td className="px-6 py-4 text-right text-[#8B4513]/80">{p.qty}</td>
+                        <td className="px-6 py-4 text-right font-semibold text-[#8B4513]">{p.revenue}</td>
                       </tr>
                     ))
                   )}
@@ -160,57 +176,67 @@ export default function AdminDashboardPage() {
             </div>
           </div>
 
-          <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
-            <h3 className="text-xl font-semibold text-[var(--color-choco)]">รายการงานด่วนวันนี้</h3>
-            <p className="mt-1 text-sm text-[var(--color-choco)]/60">
+          {/* Tasks List */}
+          <div className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur">
+            <h3 className="text-xl font-bold text-[#8B4513]">รายการงานด่วนวันนี้</h3>
+            <p className="mt-1 text-[#8B4513]/70">
               จัดลำดับความสำคัญเพื่อให้ทีมในครัวและหน้าร้านทำงานสอดคล้องกัน
             </p>
-            <ul className="mt-5 space-y-4">
+            <ul className="mt-6 space-y-4">
               {reminders.map((item, index) => (
-                <li key={`${item.title}-${index}`} className="rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-rose)]/5 p-4">
-                  <p className="font-semibold text-[var(--color-choco)]">{item.title}</p>
-                  <p className="mt-1 text-sm leading-relaxed text-[var(--color-choco)]/65">{item.detail}</p>
+                <li key={`${item.title}-${index}`} className="rounded-[1.5rem] border border-[#D2691E]/20 bg-[#F5DEB3]/20 p-5 shadow-sm transition-all hover:shadow-md">
+                  <p className="font-semibold text-[#8B4513] flex items-center gap-2">
+                    <span className="text-[#D2691E]">⚡</span>
+                    {item.title}
+                  </p>
+                  <p className="mt-2 text-[#8B4513]/80 leading-relaxed">{item.detail}</p>
                 </li>
               ))}
             </ul>
           </div>
         </div>
 
+        {/* Right Column */}
         <div className="space-y-6">
-          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
-            <h3 className="text-lg font-semibold text-[var(--color-choco)]">โน้ตสำหรับทีมงาน</h3>
-            <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/70">
-              <li className="flex items-start gap-3">
-                <span className="mt-1 text-lg">🕒</span>
-                <span>จัดรอบอบขนมปังเพิ่มในช่วงบ่าย หากยอดขายยังคงสูงกว่าวันปกติ</span>
+          {/* Team Notes */}
+          <div className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur">
+            <h3 className="text-lg font-bold text-[#8B4513]">โน้ตสำหรับทีมงาน</h3>
+            <ul className="mt-4 space-y-4">
+              <li className="flex items-start gap-3 p-3 rounded-[1rem] bg-[#E6F3FF]/60 border border-[#87CEEB]/30 shadow-sm">
+                <span className="text-2xl">🕒</span>
+                <span className="text-[#8B4513]/80 leading-relaxed">จัดรอบอบขนมปังเพิ่มในช่วงบ่าย หากยอดขายยังคงสูงกว่าวันปกติ</span>
               </li>
-              <li className="flex items-start gap-3">
-                <span className="mt-1 text-lg">💬</span>
-                <span>ตอบแชทลูกค้าจาก Facebook &amp; LINE ให้ครบถ้วน เพื่อไม่ให้พลาดโอกาสขาย</span>
+              <li className="flex items-start gap-3 p-3 rounded-[1rem] bg-[#F0F8E6]/60 border border-[#98FB98]/30 shadow-sm">
+                <span className="text-2xl">💬</span>
+                <span className="text-[#8B4513]/80 leading-relaxed">ตอบแชทลูกค้าจาก Facebook &amp; LINE ให้ครบถ้วน เพื่อไม่ให้พลาดโอกาสขาย</span>
               </li>
-              <li className="flex items-start gap-3">
-                <span className="mt-1 text-lg">🚚</span>
-                <span>ตรวจสอบที่อยู่จัดส่งใหม่และยืนยันรอบรับสินค้ากับบริษัทขนส่ง</span>
+              <li className="flex items-start gap-3 p-3 rounded-[1rem] bg-[#F5F0FF]/60 border border-[#DDA0DD]/30 shadow-sm">
+                <span className="text-2xl">🚚</span>
+                <span className="text-[#8B4513]/80 leading-relaxed">ตรวจสอบที่อยู่จัดส่งใหม่และยืนยันรอบรับสินค้ากับบริษัทขนส่ง</span>
               </li>
             </ul>
           </div>
 
-          <div className="rounded-3xl border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 p-6 text-sm text-[var(--color-choco)]">
-            <h3 className="text-lg font-semibold text-[var(--color-rose-dark)]">ลิงก์ด่วน</h3>
+          {/* Quick Links */}
+          <div className="rounded-[2rem] border border-[#D2691E]/30 bg-[#F5DEB3]/20 p-6 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur">
+            <h3 className="text-lg font-bold text-[#8B4513]">ลิงก์ด่วน</h3>
             <ul className="mt-4 space-y-3">
               <li>
-                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/products">
-                  ➕ เพิ่มสินค้าใหม่
+                <a className="flex items-center gap-3 rounded-[1rem] bg-white/80 border border-white/60 px-4 py-3 font-semibold text-[#D2691E] shadow-sm transition hover:shadow-md hover:scale-105 hover:bg-white" href="/admin/products">
+                  <span className="text-xl">➕</span>
+                  เพิ่มสินค้าใหม่
                 </a>
               </li>
               <li>
-                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/orders">
-                  📦 ติดตามคำสั่งซื้อ
+                <a className="flex items-center gap-3 rounded-[1rem] bg-white/80 border border-white/60 px-4 py-3 font-semibold text-[#D2691E] shadow-sm transition hover:shadow-md hover:scale-105 hover:bg-white" href="/admin/orders">
+                  <span className="text-xl">📦</span>
+                  ติดตามคำสั่งซื้อ
                 </a>
               </li>
               <li>
-                <a className="inline-flex items-center gap-2 rounded-full border border-transparent bg-white/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)]/40 hover:bg-white" href="/admin/coupons">
-                  🎉 สร้างคูปองโปรโมชัน
+                <a className="flex items-center gap-3 rounded-[1rem] bg-white/80 border border-white/60 px-4 py-3 font-semibold text-[#D2691E] shadow-sm transition hover:shadow-md hover:scale-105 hover:bg-white" href="/admin/coupons">
+                  <span className="text-xl">🎉</span>
+                  สร้างคูปองโปรโมชัน
                 </a>
               </li>
             </ul>
@@ -221,14 +247,43 @@ export default function AdminDashboardPage() {
   );
 }
 
-function StatCard({ title, value, caption, accent }) {
+function StatCard({ title, value, caption, color, icon }) {
+  const colorConfig = {
+    green: {
+      bg: "bg-[#F0F8E6]/60",
+      border: "border-[#98FB98]/40",
+      text: "text-[#228B22]",
+      value: "text-[#8B4513]",
+      accent: "bg-[#98FB98]/20"
+    },
+    blue: {
+      bg: "bg-[#E6F3FF]/60",
+      border: "border-[#87CEEB]/40", 
+      text: "text-[#4682B4]",
+      value: "text-[#8B4513]",
+      accent: "bg-[#87CEEB]/20"
+    },
+    orange: {
+      bg: "bg-[#FFF8E1]/60",
+      border: "border-[#FFB74D]/40",
+      text: "text-[#FF8C00]", 
+      value: "text-[#8B4513]",
+      accent: "bg-[#FFB74D]/20"
+    }
+  };
+
+  const config = colorConfig[color] || colorConfig.blue;
+
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
-      <div className={`pointer-events-none absolute -right-10 -top-16 h-36 w-36 rounded-full bg-gradient-to-br ${accent}`} />
+    <div className={`relative overflow-hidden rounded-[1.5rem] border ${config.border} ${config.bg} p-6 shadow-lg shadow-[rgba(139,69,19,0.1)] hover:shadow-xl transition-all hover:scale-105 backdrop-blur`}>
+      <div className={`absolute -right-4 -top-4 h-16 w-16 rounded-full ${config.accent}`} />
       <div className="relative">
-        <p className="text-sm font-medium text-[var(--color-choco)]/70">{title}</p>
-        <p className="mt-4 text-3xl font-semibold text-[var(--color-rose-dark)]">{value}</p>
-        <p className="mt-2 text-xs leading-relaxed text-[var(--color-choco)]/60">{caption}</p>
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-2xl">{icon}</span>
+          <p className={`text-sm font-semibold ${config.text}`}>{title}</p>
+        </div>
+        <p className={`text-3xl font-bold ${config.value} mb-2`}>{value}</p>
+        <p className="text-xs text-[#8B4513]/70 leading-relaxed">{caption}</p>
       </div>
     </div>
   );

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -62,7 +62,7 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="space-y-12">
-      <section className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-[#f5a25d20] backdrop-blur">
+      <section className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-[rgba(240,200,105,0.2)] backdrop-blur">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <h2 className="text-3xl font-semibold text-[var(--color-rose-dark)]">
@@ -93,26 +93,26 @@ export default function AdminDashboardPage() {
             title="ยอดขายวันนี้"
             value={`฿${cards.todaySales}`}
             caption="เปรียบเทียบจากยอดรวมที่ยืนยันแล้ว"
-            accent="from-[#f3d36b]/80 via-[#f7c68b]/40 to-transparent"
+            accent="from-[#f3d36b]/80 via-[var(--color-rose-dark)]/40 to-transparent"
           />
           <StatCard
             title="ออเดอร์ใหม่"
             value={cards.newOrders}
             caption="ตรวจสอบรายละเอียดก่อน 18:00 น. เพื่อจัดส่งทันวันถัดไป"
-            accent="from-[#f5a25d]/60 via-[#f3d36b]/40 to-transparent"
+            accent="from-[var(--color-rose)]/60 via-[var(--color-gold)]/40 to-transparent"
           />
           <StatCard
             title="สินค้าใกล้หมด"
             value={cards.lowStock}
             caption="เติมสต็อกล่วงหน้าเพื่อไม่ให้ยอดขายสะดุด"
-            accent="from-[#7cd1b8]/60 via-[#f3d36b]/40 to-transparent"
+            accent="from-[#7cd1b8]/60 via-[var(--color-gold)]/40 to-transparent"
           />
         </div>
       </section>
 
       <section className="grid gap-8 lg:grid-cols-3">
         <div className="lg:col-span-2 space-y-6">
-          <div className="rounded-3xl border border-[#f4c689]/40 bg-[#fff7f0]/80 p-6 shadow-lg shadow-[#f5a25d18]">
+          <div className="rounded-3xl border border-[var(--color-rose)]/30 bg-[rgba(240,200,105,0.12)]/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h3 className="text-xl font-semibold text-[var(--color-choco)]">
@@ -124,7 +124,7 @@ export default function AdminDashboardPage() {
               </div>
               <a
                 href="/api/admin/export/sales"
-                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)]"
+                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
               >
                 ⬇️ ดาวน์โหลด CSV
               </a>
@@ -160,7 +160,7 @@ export default function AdminDashboardPage() {
             </div>
           </div>
 
-          <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-[#f5a25d18]">
+          <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
             <h3 className="text-xl font-semibold text-[var(--color-choco)]">รายการงานด่วนวันนี้</h3>
             <p className="mt-1 text-sm text-[var(--color-choco)]/60">
               จัดลำดับความสำคัญเพื่อให้ทีมในครัวและหน้าร้านทำงานสอดคล้องกัน
@@ -177,7 +177,7 @@ export default function AdminDashboardPage() {
         </div>
 
         <div className="space-y-6">
-          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d18]">
+          <div className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.09)]">
             <h3 className="text-lg font-semibold text-[var(--color-choco)]">โน้ตสำหรับทีมงาน</h3>
             <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/70">
               <li className="flex items-start gap-3">
@@ -223,7 +223,7 @@ export default function AdminDashboardPage() {
 
 function StatCard({ title, value, caption, accent }) {
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/90 p-6 shadow-lg shadow-[#f5a25d14]">
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/90 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)]">
       <div className={`pointer-events-none absolute -right-10 -top-16 h-36 w-36 rounded-full bg-gradient-to-br ${accent}`} />
       <div className="relative">
         <p className="text-sm font-medium text-[var(--color-choco)]/70">{title}</p>

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -152,7 +152,7 @@ export default function AdminProductsPage() {
 
   return (
     <main className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการสินค้า</h2>
@@ -174,7 +174,7 @@ export default function AdminProductsPage() {
               </span>
             </div>
             <button
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)]"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
               onClick={startCreate}
             >
               ➕ เพิ่มสินค้าใหม่
@@ -183,14 +183,14 @@ export default function AdminProductsPage() {
         </div>
 
         <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <StatBubble label="สินค้าทั้งหมด" value={filteredItems.length} tone="from-[#f3d36b]/30 via-[#f7c68b]/20 to-transparent" />
-          <StatBubble label="กำลังขาย" value={activeCount} tone="from-[#7cd1b8]/30 via-[#f3d36b]/20 to-transparent" />
-          <StatBubble label="ซ่อนอยู่" value={hiddenCount} tone="from-[#f5a25d]/30 via-[#f7c68b]/20 to-transparent" />
-          <StatBubble label="รอดำเนินการ" value={loading ? "กำลังโหลด" : "พร้อมจัดการ"} tone="from-[#c4b5fd]/30 via-[#f7c68b]/10 to-transparent" />
+          <StatBubble label="สินค้าทั้งหมด" value={filteredItems.length} tone="from-[#f3d36b]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
+          <StatBubble label="กำลังขาย" value={activeCount} tone="from-[#7cd1b8]/30 via-[var(--color-gold)]/20 to-transparent" />
+          <StatBubble label="ซ่อนอยู่" value={hiddenCount} tone="from-[var(--color-rose)]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
+          <StatBubble label="รอดำเนินการ" value={loading ? "กำลังโหลด" : "พร้อมจัดการ"} tone="from-[#c4b5fd]/30 via-[var(--color-rose-dark)]/10 to-transparent" />
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f5a25d18]">
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h3>
@@ -221,7 +221,7 @@ export default function AdminProductsPage() {
               </thead>
               <tbody>
                 {filteredItems.map((p) => (
-                  <tr key={p._id} className="rounded-3xl bg-white/80 shadow shadow-[#f5a25d12]">
+                  <tr key={p._id} className="rounded-3xl bg-white/80 shadow shadow-[rgba(240,200,105,0.07)]">
                     <td className="px-4 py-4">
                       <div className="flex items-center gap-3">
                         <div className="h-16 w-16 overflow-hidden rounded-2xl bg-[#fff5e4]">
@@ -284,7 +284,7 @@ export default function AdminProductsPage() {
 
       {editing !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
-          <div className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/80 bg-white/95 shadow-2xl shadow-[#f5a25d30]">
+          <div className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/80 bg-white/95 shadow-2xl shadow-[rgba(240,200,105,0.3)]">
             <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
               <div>
                 <h3 className="text-lg font-semibold text-[var(--color-choco)]">
@@ -419,7 +419,7 @@ export default function AdminProductsPage() {
                     ยกเลิก
                   </button>
                   <button
-                    className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={saving}
                   >
                     {saving ? "กำลังบันทึก..." : isEdit ? "บันทึกการแก้ไข" : "สร้างสินค้า"}

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -18,6 +18,32 @@ function toSlug(s) {
   return slugify(String(s || ""), { lower: true, strict: true, trim: true });
 }
 
+// New Sliding Toggle Component
+function SlidingToggle({ isActive, onToggle, disabled = false }) {
+  return (
+    <button
+      onClick={onToggle}
+      disabled={disabled}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-[#D2691E] focus:ring-offset-2 ${
+        isActive 
+          ? 'bg-[#228B22]' 
+          : 'bg-gray-300'
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      title={isActive ? "คลิกเพื่อซ่อนสินค้า" : "คลิกเพื่อแสดงสินค้า"}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white shadow-lg transition-transform duration-300 ${
+          isActive ? 'translate-x-7' : 'translate-x-1'
+        }`}
+      >
+        <span className="flex h-full w-full items-center justify-center text-xs">
+          {isActive ? '✓' : '✕'}
+        </span>
+      </span>
+    </button>
+  );
+}
+
 export default function AdminProductsPage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -151,12 +177,13 @@ export default function AdminProductsPage() {
   const hiddenCount = filteredItems.length - activeCount;
 
   return (
-    <main className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <main className="space-y-8">
+      {/* Header Section */}
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 p-8 shadow-xl shadow-[rgba(139,69,19,0.2)] backdrop-blur">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div>
-            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการสินค้า</h2>
-            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+            <h2 className="text-2xl font-bold text-[#8B4513]">จัดการสินค้า</h2>
+            <p className="mt-1 text-[#8B4513]/70">
               เพิ่ม แก้ไข และควบคุมการแสดงผลสินค้าให้ตรงกับสต็อกจริงในร้าน
             </p>
           </div>
@@ -167,14 +194,14 @@ export default function AdminProductsPage() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="ค้นหาสินค้า ชื่อ หรือแท็ก"
-                className="w-60 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                className="w-60 rounded-full border border-[#D2691E]/30 bg-white/70 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
               />
-              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-[var(--color-choco)]/50">
+              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-[#8B4513]/50">
                 🔍
               </span>
             </div>
             <button
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)]"
+              className="inline-flex items-center gap-2 rounded-full bg-[#D2691E] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(139,69,19,0.25)] transition hover:bg-[#8B4513]"
               onClick={startCreate}
             >
               ➕ เพิ่มสินค้าใหม่
@@ -182,131 +209,219 @@ export default function AdminProductsPage() {
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <StatBubble label="สินค้าทั้งหมด" value={filteredItems.length} tone="from-[#f3d36b]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
-          <StatBubble label="กำลังขาย" value={activeCount} tone="from-[#7cd1b8]/30 via-[var(--color-gold)]/20 to-transparent" />
-          <StatBubble label="ซ่อนอยู่" value={hiddenCount} tone="from-[var(--color-rose)]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
-          <StatBubble label="รอดำเนินการ" value={loading ? "กำลังโหลด" : "พร้อมจัดการ"} tone="from-[#c4b5fd]/30 via-[var(--color-rose-dark)]/10 to-transparent" />
+        {/* Stats Cards */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatBubble label="สินค้าทั้งหมด" value={filteredItems.length} color="blue" />
+          <StatBubble label="กำลังขาย" value={activeCount} color="green" />
+          <StatBubble label="ซ่อนอยู่" value={hiddenCount} color="orange" />
+          <StatBubble label="สถานะ" value={loading ? "กำลังโหลด" : "พร้อมจัดการ"} color="purple" />
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
+      {/* Products Table */}
+      <section className="rounded-[2rem] border border-white/70 bg-white/80 shadow-xl shadow-[rgba(139,69,19,0.15)] backdrop-blur overflow-hidden">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการสินค้า</h3>
-            <p className="text-xs text-[var(--color-choco)]/60">
+            <h3 className="text-lg font-bold text-[#8B4513]">รายการสินค้า</h3>
+            <p className="text-xs text-[#8B4513]/60">
               อัปเดตสต็อกและราคาได้ทันที ตารางรองรับการเลื่อนในแนวนอนได้บนมือถือ
             </p>
           </div>
-          <span className="text-xs font-medium uppercase tracking-wide text-[var(--color-choco)]/50">
+          <span className="text-xs font-medium uppercase tracking-wide text-[#8B4513]/50">
             {filteredItems.length} รายการที่แสดง
           </span>
         </header>
 
-        {loading && <p className="px-6 py-6 text-sm text-[var(--color-choco)]/70">กำลังโหลดข้อมูลสินค้า...</p>}
-        {err && !loading && <p className="px-6 py-6 text-sm text-rose-600">{err}</p>}
+        {loading && (
+          <div className="flex items-center justify-center px-6 py-8">
+            <div className="flex items-center gap-3">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-[#D2691E] border-t-transparent"></div>
+              <span className="text-sm text-[#8B4513]/70">กำลังโหลดข้อมูลสินค้า...</span>
+            </div>
+          </div>
+        )}
+
+        {err && !loading && (
+          <div className="flex items-center justify-center px-6 py-8">
+            <div className="rounded-[1.5rem] bg-red-50 border border-red-200 px-6 py-4 text-center">
+              <span className="text-2xl mb-2 block">⚠️</span>
+              <span className="text-sm text-red-600">{err}</span>
+            </div>
+          </div>
+        )}
 
         {!loading && !err && (
-          <div className="overflow-x-auto">
-            <table className="min-w-full border-separate border-spacing-y-2 px-4 py-4 text-sm">
-              <thead>
-                <tr className="text-left text-xs uppercase tracking-wide text-[var(--color-choco)]/50">
-                  <th className="px-4 py-2">สินค้า</th>
-                  <th className="px-4 py-2">ราคา</th>
-                  <th className="px-4 py-2">สต็อก</th>
-                  <th className="px-4 py-2">สถานะ</th>
-                  <th className="px-4 py-2">แท็ก</th>
-                  <th className="px-4 py-2 text-right">จัดการ</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredItems.map((p) => (
-                  <tr key={p._id} className="rounded-3xl bg-white/80 shadow shadow-[rgba(240,200,105,0.07)]">
-                    <td className="px-4 py-4">
-                      <div className="flex items-center gap-3">
-                        <div className="h-16 w-16 overflow-hidden rounded-2xl bg-[#fff5e4]">
-                          {p.images?.[0] ? (
-                            <img src={p.images[0]} alt={p.title} className="h-full w-full object-cover" />
-                          ) : (
-                            <div className="flex h-full w-full items-center justify-center text-xs text-[var(--color-choco)]/40">
-                              ไม่มีรูป
-                            </div>
-                          )}
+          <div className="overflow-hidden">
+            {/* Mobile Cards */}
+            <div className="block lg:hidden p-4 space-y-4">
+              {filteredItems.length === 0 ? (
+                <div className="text-center py-8">
+                  <span className="text-4xl mb-4 block">🛍️</span>
+                  <span className="text-[#8B4513]/60">ไม่พบสินค้าที่ตรงกับคำค้นหา</span>
+                </div>
+              ) : (
+                filteredItems.map((p) => (
+                  <div key={p._id} className="rounded-[1.5rem] bg-white/90 border border-white/60 p-4 shadow-sm">
+                    <div className="flex items-start gap-4">
+                      <div className="h-16 w-16 overflow-hidden rounded-[1rem] bg-[#F5DEB3]/30 flex-shrink-0">
+                        {p.images?.[0] ? (
+                          <img src={p.images[0]} alt={p.title} className="h-full w-full object-cover" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-xs text-[#8B4513]/40">
+                            ไม่มีรูป
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold text-[#8B4513] truncate">{p.title}</h4>
+                        <p className="text-xs text-[#8B4513]/50 truncate">{p.slug}</p>
+                        <div className="flex items-center gap-4 mt-2 text-sm">
+                          <span className="font-semibold text-[#8B4513]">฿{p.price}</span>
+                          <span className="text-[#8B4513]/70">สต็อก: {p.stock}</span>
                         </div>
-                        <div>
-                          <p className="font-semibold text-[var(--color-choco)]">{p.title}</p>
-                          <p className="text-xs text-[var(--color-choco)]/50">{p.slug}</p>
+                        <div className="flex items-center justify-between mt-3">
+                          <div className="flex items-center gap-3">
+                            <SlidingToggle 
+                              isActive={p.active}
+                              onToggle={() => toggleActive(p)}
+                            />
+                            <span className="text-xs text-[#8B4513]/70">
+                              {p.active ? "กำลังขาย" : "ซ่อนอยู่"}
+                            </span>
+                          </div>
+                          <div className="flex gap-2">
+                            <button
+                              className="rounded-full border border-[#D2691E]/30 px-3 py-1 text-xs font-semibold text-[#D2691E] transition hover:bg-[#D2691E]/10"
+                              onClick={() => startEdit(p)}
+                            >
+                              แก้ไข
+                            </button>
+                            <button
+                              className="rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-500 transition hover:bg-red-50"
+                              onClick={() => onDelete(p)}
+                            >
+                              ลบ
+                            </button>
+                          </div>
                         </div>
                       </div>
-                    </td>
-                    <td className="px-4 py-4 font-semibold text-[var(--color-choco)]">฿{p.price}</td>
-                    <td className="px-4 py-4 text-[var(--color-choco)]">{p.stock}</td>
-                    <td className="px-4 py-4">
-                      <button
-                        onClick={() => toggleActive(p)}
-                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition ${
-                          p.active
-                            ? "bg-[var(--color-rose)]/15 text-[var(--color-rose)]"
-                            : "bg-gray-200 text-gray-500"
-                        }`}
-                        title={p.active ? "คลิกเพื่อซ่อนสินค้า" : "คลิกเพื่อแสดงสินค้า"}
-                      >
-                        <span className="text-base">{p.active ? "🟢" : "⚪️"}</span>
-                        {p.active ? "กำลังขาย" : "ซ่อนอยู่"}
-                      </button>
-                    </td>
-                    <td className="px-4 py-4 text-xs text-[var(--color-choco)]/60">
-                      {Array.isArray(p.tags) && p.tags.length > 0 ? p.tags.join(", ") : "-"}
-                    </td>
-                    <td className="px-4 py-4 text-right">
-                      <div className="flex justify-end gap-2">
-                        <button
-                          className="rounded-full border border-[var(--color-rose)]/40 px-4 py-1 text-xs font-semibold text-[var(--color-rose)] transition hover:border-[var(--color-rose)] hover:bg-[var(--color-rose)]/10"
-                          onClick={() => startEdit(p)}
-                        >
-                          แก้ไข
-                        </button>
-                        <button
-                          className="rounded-full border border-rose-200 px-4 py-1 text-xs font-semibold text-rose-500 transition hover:border-rose-400 hover:bg-rose-100"
-                          onClick={() => onDelete(p)}
-                        >
-                          ลบ
-                        </button>
-                      </div>
-                    </td>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Desktop Table */}
+            <div className="hidden lg:block overflow-x-auto">
+              <table className="min-w-full text-sm ">
+                <thead>
+                  <tr className="bg-[#F5DEB3]/30 border-b border-white/40">
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">สินค้า</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">ราคา</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">สต็อก</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">สถานะ</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#8B4513]">แท็ก</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#8B4513]">จัดการ</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-white/40">
+                  {filteredItems.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-6 py-12 text-center">
+                        <div className="flex flex-col items-center">
+                          <span className="text-4xl mb-4">🛍️</span>
+                          <span className="text-[#8B4513]/60">ไม่พบสินค้าที่ตรงกับคำค้นหา</span>
+                        </div>
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredItems.map((p, idx) => (
+                      <tr key={p._id} className={`transition-colors hover:bg-white/70 ${idx % 2 === 0 ? 'bg-white/50' : 'bg-[#FFF8DC]/30'}`}>
+                        <td className="px-6 py-4 ">
+                          <div className="flex items-center gap-3">
+                            <div className="h-16 w-16 overflow-hidden rounded-[1rem] bg-[#F5DEB3]/30 flex-shrink-0">
+                              {p.images?.[0] ? (
+                                <img src={p.images[0]} alt={p.title} className="h-full w-full object-cover" />
+                              ) : (
+                                <div className="flex h-full w-full items-center justify-center text-xs text-[#8B4513]/40">
+                                  ไม่มีรูป
+                                </div>
+                              )}
+                            </div>
+                            <div>
+                              <p className="font-semibold text-[#8B4513]">{p.title}</p>
+                              <p className="text-xs text-[#8B4513]/50">{p.slug}</p>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 font-semibold text-[#8B4513]">฿{p.price}</td>
+                        <td className="px-6 py-4 text-[#8B4513]">{p.stock}</td>
+                        <td className="px-6 py-4">
+                          <div className="flex items-center gap-3">
+                            <SlidingToggle 
+                              isActive={p.active}
+                              onToggle={() => toggleActive(p)}
+                            />
+                            <span className="text-xs text-[#8B4513]/70">
+                              {p.active ? "กำลังขาย" : "ซ่อนอยู่"}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 text-xs text-[#8B4513]/60">
+                          {Array.isArray(p.tags) && p.tags.length > 0 ? p.tags.join(", ") : "-"}
+                        </td>
+                        <td className="px-6 py-4 text-right">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              className="rounded-full border border-[#D2691E]/30 px-4 py-1 text-xs font-semibold text-[#D2691E] transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+                              onClick={() => startEdit(p)}
+                            >
+                              แก้ไข
+                            </button>
+                            <button
+                              className="rounded-full border border-red-200 px-4 py-1 text-xs font-semibold text-red-500 transition hover:border-red-400 hover:bg-red-50"
+                              onClick={() => onDelete(p)}
+                            >
+                              ลบ
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </section>
 
+      {/* Modal */}
       {editing !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur-sm">
-          <div className="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/80 bg-white/95 shadow-2xl shadow-[rgba(240,200,105,0.3)]">
-            <div className="flex items-center justify-between border-b border-white/60 bg-[var(--color-rose)]/10 px-6 py-4">
+          <div className="relative w-full max-w-4xl overflow-hidden rounded-[2rem] border border-white/80 bg-white/95 shadow-2xl shadow-[rgba(139,69,19,0.3)] backdrop-blur">
+            <div className="flex items-center justify-between border-b border-white/60 bg-[#F5DEB3]/20 px-6 py-4">
               <div>
-                <h3 className="text-lg font-semibold text-[var(--color-choco)]">
+                <h3 className="text-lg font-bold text-[#8B4513]">
                   {isEdit ? "แก้ไขสินค้า" : "เพิ่มสินค้าใหม่"}
                 </h3>
-                <p className="text-xs text-[var(--color-choco)]/60">
+                <p className="text-xs text-[#8B4513]/60">
                   กรอกข้อมูลให้ครบถ้วนเพื่อให้หน้าเว็บแสดงผลสวยงามและถูกต้อง
                 </p>
               </div>
               <button
-                className="rounded-full border border-[var(--color-choco)]/10 bg-white px-3 py-1 text-xs font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/30 hover:text-[var(--color-choco)]"
+                className="rounded-full border border-[#8B4513]/20 bg-white px-3 py-1 text-xs font-semibold text-[#8B4513]/70 transition hover:border-[#8B4513]/30 hover:text-[#8B4513]"
                 onClick={() => setEditing(null)}
               >
                 ปิด
               </button>
             </div>
 
-            <form onSubmit={onSubmit} className="grid gap-6 px-6 py-6 md:grid-cols-[1.2fr_1fr]">
+            <form onSubmit={onSubmit} className="grid gap-6 px-6 py-6 md:grid-cols-[1.2fr_1fr] ">
               <div className="space-y-4">
                 <Field label="ชื่อสินค้า" required>
                   <input
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.title}
                     onChange={(e) =>
                       setForm((f) => ({
@@ -319,7 +434,7 @@ export default function AdminProductsPage() {
                 </Field>
                 <Field label="Slug">
                   <input
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.slug}
                     onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
                   />
@@ -329,7 +444,7 @@ export default function AdminProductsPage() {
                     <input
                       type="number"
                       min={0}
-                      className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                      className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                       value={form.price}
                       onChange={(e) =>
                         setForm((f) => ({ ...f, price: Number(e.target.value || 0) }))
@@ -340,7 +455,7 @@ export default function AdminProductsPage() {
                     <input
                       type="number"
                       min={0}
-                      className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                      className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                       value={form.stock}
                       onChange={(e) =>
                         setForm((f) => ({ ...f, stock: Number(e.target.value || 0) }))
@@ -350,37 +465,37 @@ export default function AdminProductsPage() {
                 </div>
                 <Field label="แท็ก (คั่นด้วย ,)">
                   <input
-                    className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.tags}
                     onChange={(e) => setForm((f) => ({ ...f, tags: e.target.value }))}
                   />
                 </Field>
-                <label className="flex items-center gap-3 text-sm font-medium text-[var(--color-choco)]/80">
-                  <input
-                    type="checkbox"
-                    checked={form.active}
-                    onChange={(e) => setForm((f) => ({ ...f, active: e.target.checked }))}
-                    className="h-4 w-4 rounded border-[var(--color-rose)]/40 text-[var(--color-rose)] focus:ring-[var(--color-rose)]"
+                <div className="flex items-center gap-3">
+                  <SlidingToggle 
+                    isActive={form.active}
+                    onToggle={() => setForm((f) => ({ ...f, active: !f.active }))}
                   />
-                  แสดงสินค้าบนหน้าร้าน
-                </label>
+                  <label className="text-sm font-medium text-[#8B4513]/80">
+                    แสดงสินค้าบนหน้าร้าน
+                  </label>
+                </div>
               </div>
 
               <div className="space-y-4">
                 <Field label="คำอธิบาย">
                   <textarea
-                    className="h-32 w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                    className="h-32 w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                     value={form.description}
                     onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
                   />
                 </Field>
                 <Field label="รูปสินค้า">
                   <div className="flex flex-col gap-4 sm:flex-row">
-                    <div className="h-28 w-28 overflow-hidden rounded-2xl border border-white/70 bg-[#fff5e4] shadow-inner">
+                    <div className="h-28 w-28 overflow-hidden rounded-[1rem] border border-white/70 bg-[#F5DEB3]/30 shadow-inner flex-shrink-0">
                       {form.image ? (
                         <img src={form.image} alt="preview" className="h-full w-full object-cover" />
                       ) : (
-                        <div className="flex h-full w-full items-center justify-center text-xs text-[var(--color-choco)]/50">
+                        <div className="flex h-full w-full items-center justify-center text-xs text-[#8B4513]/50">
                           รออัปโหลด
                         </div>
                       )}
@@ -398,10 +513,10 @@ export default function AdminProductsPage() {
                             alert(String(error.message || error));
                           }
                         }}
-                        className="w-full rounded-2xl border border-dashed border-[var(--color-rose)]/40 bg-white/70 px-4 py-3 text-sm text-[var(--color-choco)]/70 file:mr-4 file:rounded-full file:border-0 file:bg-[var(--color-rose)]/10 file:px-4 file:py-2 file:text-[var(--color-rose)]"
+                        className="w-full rounded-[1rem] border border-dashed border-[#D2691E]/40 bg-white/70 px-4 py-3 text-sm text-[#8B4513]/70 file:mr-4 file:rounded-full file:border-0 file:bg-[#D2691E]/10 file:px-4 file:py-2 file:text-[#D2691E]"
                       />
                       <input
-                        className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-white/80 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                        className="w-full rounded-[1rem] border border-[#D2691E]/20 bg-white/80 px-4 py-2 text-sm text-[#8B4513] shadow-inner focus:border-[#D2691E] focus:outline-none"
                         placeholder="หรือวาง URL รูปสินค้า"
                         value={form.image}
                         onChange={(e) => setForm((f) => ({ ...f, image: e.target.value }))}
@@ -410,16 +525,16 @@ export default function AdminProductsPage() {
                   </div>
                 </Field>
 
-                <div className="flex flex-wrap justify-end gap-3 pt-2">
+                <div className="flex flex-wrap justify-end gap-3 pt-4">
                   <button
                     type="button"
-                    className="rounded-full border border-[var(--color-choco)]/20 px-5 py-2 text-sm font-semibold text-[var(--color-choco)]/70 transition hover:border-[var(--color-choco)]/40 hover:text-[var(--color-choco)]"
+                    className="rounded-full border border-[#8B4513]/20 px-5 py-2 text-sm font-semibold text-[#8B4513]/70 transition hover:border-[#8B4513]/40 hover:text-[#8B4513]"
                     onClick={() => setEditing(null)}
                   >
                     ยกเลิก
                   </button>
                   <button
-                    className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-full bg-[#D2691E] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[rgba(139,69,19,0.25)] transition hover:bg-[#8B4513] disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={saving}
                   >
                     {saving ? "กำลังบันทึก..." : isEdit ? "บันทึกการแก้ไข" : "สร้างสินค้า"}
@@ -436,23 +551,32 @@ export default function AdminProductsPage() {
 
 function Field({ label, required, children }) {
   return (
-    <label className="block text-sm font-medium text-[var(--color-choco)]/80">
+    <label className="block text-sm font-medium text-[#8B4513]/80">
       <span className="mb-2 block">
         {label}
-        {required ? <span className="ml-1 text-rose-500">*</span> : null}
+        {required ? <span className="ml-1 text-red-500">*</span> : null}
       </span>
       {children}
     </label>
   );
 }
 
-function StatBubble({ label, value, tone }) {
+function StatBubble({ label, value, color }) {
+  const colorConfig = {
+    blue: { bg: "bg-[#E6F3FF]/60", border: "border-[#87CEEB]/40", accent: "bg-[#87CEEB]/20" },
+    green: { bg: "bg-[#F0F8E6]/60", border: "border-[#98FB98]/40", accent: "bg-[#98FB98]/20" },
+    orange: { bg: "bg-[#FFF8E1]/60", border: "border-[#FFB74D]/40", accent: "bg-[#FFB74D]/20" },
+    purple: { bg: "bg-[#F5F0FF]/60", border: "border-[#DDA0DD]/40", accent: "bg-[#DDA0DD]/20" }
+  };
+
+  const config = colorConfig[color] || colorConfig.blue;
+
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-white/70 bg-white/80 p-4 text-sm font-semibold text-[var(--color-choco)] shadow-inner">
-      <div className={`pointer-events-none absolute -right-6 -top-6 h-20 w-20 rounded-full bg-gradient-to-br ${tone}`} />
+    <div className={`relative overflow-hidden rounded-[1.5rem] border ${config.border} ${config.bg} p-4 shadow-sm hover:shadow-md transition-shadow backdrop-blur`}>
+      <div className={`absolute -right-4 -top-4 h-16 w-16 rounded-full ${config.accent}`} />
       <div className="relative">
-        <p className="text-xs uppercase tracking-wide text-[var(--color-choco)]/50">{label}</p>
-        <p className="mt-2 text-xl text-[var(--color-rose-dark)]">{value}</p>
+        <p className="text-xs uppercase tracking-wide text-[#8B4513]/60 font-semibold">{label}</p>
+        <p className="mt-2 text-xl font-bold text-[#8B4513]">{value}</p>
       </div>
     </div>
   );

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -130,7 +130,7 @@ export default function AdminUsersPage() {
 
   return (
     <div className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการผู้ใช้งาน</h2>
@@ -153,13 +153,13 @@ export default function AdminUsersPage() {
         </div>
 
         <div className="mt-6 grid gap-4 sm:grid-cols-3">
-          <StatCard label="ผู้ใช้ทั้งหมด" value={stats.total} tone="from-[#f3d36b]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
-          <StatCard label="ผู้ดูแลระบบ" value={stats.adminCount} tone="from-[#7cd1b8]/30 via-[var(--color-gold)]/20 to-transparent" />
-          <StatCard label="ถูกระงับ" value={stats.bannedCount} tone="from-[var(--color-rose)]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
+          <StatCard label="ผู้ใช้ทั้งหมด" value={stats.total} tone="from-[#f3d36b]/30 via-[#f7c68b]/20 to-transparent" />
+          <StatCard label="ผู้ดูแลระบบ" value={stats.adminCount} tone="from-[#7cd1b8]/30 via-[#f3d36b]/20 to-transparent" />
+          <StatCard label="ถูกระงับ" value={stats.bannedCount} tone="from-[#f5a25d]/30 via-[#f7c68b]/20 to-transparent" />
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
+      <section className="rounded-[2rem] border border-white/70 bg-white/70 shadow-xl shadow-[#f5a25d18] backdrop-blur-sm overflow-hidden">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการผู้ใช้งาน</h3>
@@ -167,84 +167,261 @@ export default function AdminUsersPage() {
               สามารถเปลี่ยนสิทธิ์การใช้งานหรือระงับบัญชีชั่วคราวได้จากตารางด้านล่าง
             </p>
           </div>
-          {loading && <span className="text-xs text-[var(--color-choco)]/60">กำลังโหลด...</span>}
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-[var(--color-choco)]/60">
+              <div className="h-3 w-3 animate-spin rounded-full border-2 border-[var(--color-rose)]/30 border-t-[var(--color-rose)]"></div>
+              กำลังโหลด...
+            </div>
+          )}
         </header>
 
         {err ? (
-          <div className="px-6 py-8 text-center text-sm text-rose-600">{err}</div>
+                      <div className="flex items-center justify-center px-6 py-12">
+            <div className="rounded-[1.5rem] bg-rose-50 border border-rose-200 px-6 py-4 text-center">
+              <div className="mb-2 text-2xl">⚠️</div>
+              <div className="text-sm font-medium text-rose-600">{err}</div>
+                              <button 
+                onClick={load}
+                className="mt-3 rounded-full bg-rose-100 px-4 py-2 text-xs font-semibold text-rose-700 hover:bg-rose-200 transition-colors"
+              >
+                ลองอีกครั้ง
+              </button>
+            </div>
+          </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-white/60 text-sm text-[var(--color-choco)]">
-              <thead className="bg-[#fff5e4] text-[var(--color-choco)]/80">
-                <tr>
-                  <th className="px-6 py-3 text-left font-medium">ชื่อ</th>
-                  <th className="px-6 py-3 text-left font-medium">อีเมล</th>
-                  <th className="px-6 py-3 text-left font-medium">สิทธิ์</th>
-                  <th className="px-6 py-3 text-left font-medium">สถานะ</th>
-                  <th className="px-6 py-3 text-left font-medium">สร้างเมื่อ</th>
-                  <th className="px-6 py-3 text-right font-medium">จัดการ</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredUsers.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-6 py-8 text-center text-sm text-[var(--color-choco)]/60">
-                      {loading ? "กำลังโหลดข้อมูลผู้ใช้..." : "ไม่พบผู้ใช้ที่ตรงกับคำค้นหา"}
-                    </td>
-                  </tr>
-                ) : (
-                  filteredUsers.map((user, idx) => {
+          <div className="overflow-hidden rounded-[1.5rem]">
+            {/* Mobile Cards - แสดงเฉพาะใน mobile */}
+            <div className="block lg:hidden">
+              {filteredUsers.length === 0 ? (
+                <div className="px-6 py-12 text-center">
+                  <div className="mx-auto mb-4 h-16 w-16 rounded-full bg-[var(--color-rose)]/10 flex items-center justify-center text-2xl">
+                    👤
+                  </div>
+                  <div className="text-sm font-medium text-[var(--color-choco)]/60">
+                    {loading ? "กำลังโหลดข้อมูลผู้ใช้..." : "ไม่พบผู้ใช้ที่ตรงกับคำค้นหา"}
+                  </div>
+                </div>
+              ) : (
+                                  <div className="space-y-3 p-4">
+                  {filteredUsers.map((user) => {
                     const isBusy = !!busy[user.id];
                     return (
-                      <tr key={user.id} className={idx % 2 === 0 ? "bg-white" : "bg-[#fff7f0]"}>
-                        <td className="px-6 py-4 font-medium">{user.name || "-"}</td>
-                        <td className="px-6 py-4">{user.email}</td>
-                        <td className="px-6 py-4">
-                          <select
-                            className="rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-3 py-1 text-xs font-semibold focus:border-[var(--color-rose)] focus:outline-none"
-                            value={user.role}
-                            disabled={isBusy}
-                            onChange={(e) => handleRoleChange(user, e.target.value)}
-                          >
-                            {Object.entries(roleLabels).map(([value, label]) => (
-                              <option key={value} value={value}>
-                                {label}
-                              </option>
-                            ))}
-                          </select>
-                        </td>
-                        <td className="px-6 py-4">
+                      <div key={user.id} className="rounded-[1.5rem] bg-white/80 border border-white/60 p-4 shadow-sm">
+                        <div className="flex items-start justify-between mb-3">
+                          <div>
+                            <h4 className="font-semibold text-[var(--color-choco)]">{user.name || "ไม่ระบุชื่อ"}</h4>
+                            <p className="text-sm text-[var(--color-choco)]/70">{user.email}</p>
+                          </div>
                           <span
-                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                            className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold ${
                               user.banned
                                 ? "bg-rose-100 text-rose-600"
                                 : "bg-[#e7f8f0] text-[var(--color-rose-dark)]"
                             }`}
                           >
-                            {user.banned ? "ถูกระงับ" : "ปกติ"}
+                            {user.banned ? "🔒 ถูกระงับ" : "✅ ปกติ"}
                           </span>
-                        </td>
-                        <td className="px-6 py-4 text-xs text-[var(--color-choco)]/70">{formatDate(user.createdAt)}</td>
-                        <td className="px-6 py-4 text-right">
-                          <button
-                            type="button"
-                            onClick={() => toggleBan(user)}
-                            disabled={isBusy}
-                            className={`inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs font-semibold transition ${
-                              user.banned
-                                ? "bg-[#7cd1b8]/20 text-[#0b7b59] hover:bg-[#7cd1b8]/30"
-                                : "bg-rose-100 text-rose-600 hover:bg-rose-200"
-                            } ${isBusy ? "opacity-60" : ""}`}
-                          >
-                            {isBusy ? "กำลังบันทึก..." : user.banned ? "ปลดระงับ" : "ระงับการใช้งาน"}
-                          </button>
-                        </td>
-                      </tr>
+                        </div>
+                        
+                        <div className="grid grid-cols-2 gap-3 mb-4 text-xs">
+                          <div>
+                            <span className="text-[var(--color-choco)]/60">สิทธิ์:</span>
+                            <select
+                              className="ml-2 rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-2 py-1 text-xs font-semibold focus:border-[var(--color-rose)] focus:outline-none"
+                              value={user.role}
+                              disabled={isBusy}
+                              onChange={(e) => handleRoleChange(user, e.target.value)}
+                            >
+                              {Object.entries(roleLabels).map(([value, label]) => (
+                                <option key={value} value={value}>
+                                  {label}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <span className="text-[var(--color-choco)]/60">สร้างเมื่อ:</span>
+                            <div className="text-[var(--color-choco)]/80 font-medium">{formatDate(user.createdAt)}</div>
+                          </div>
+                        </div>
+                        
+                        <button
+                          type="button"
+                          onClick={() => toggleBan(user)}
+                          disabled={isBusy}
+                          className={`w-full rounded-full px-4 py-2 text-xs font-semibold transition-all duration-200 ${
+                            user.banned
+                              ? "bg-[#7cd1b8]/20 text-[#0b7b59] hover:bg-[#7cd1b8]/30 hover:shadow-md"
+                              : "bg-rose-100 text-rose-600 hover:bg-rose-200 hover:shadow-md"
+                          } ${isBusy ? "opacity-60 cursor-not-allowed" : "hover:scale-105"}`}
+                        >
+                          {isBusy ? "⏳ กำลังบันทึก..." : user.banned ? "🔓 ปลดระงับ" : "🔒 ระงับการใช้งาน"}
+                        </button>
+                      </div>
                     );
-                  })
-                )}
-              </tbody>
-            </table>
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Desktop Table - แสดงเฉพาะใน desktop */}
+            <div className="hidden lg:block overflow-x-auto">
+              <table className="min-w-full text-sm text-[var(--color-choco)]">
+                <thead>
+                  <tr className="bg-gradient-to-r from-[#fff5e4] to-[#fef7ed] border-b border-white/40">
+                    <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center gap-2">
+                        👤 ชื่อผู้ใช้
+                      </div>
+                    </th>
+                    <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center gap-2">
+                        ✉️ อีเมล
+                      </div>
+                    </th>
+                    <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center gap-2">
+                        🔑 สิทธิ์
+                      </div>
+                    </th>
+                    <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center gap-2">
+                        📊 สถานะ
+                      </div>
+                    </th>
+                    <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center gap-2">
+                        📅 วันที่สร้าง
+                      </div>
+                    </th>
+                    <th className="px-6 py-4 text-right font-semibold text-[var(--color-choco)]/90 tracking-wide">
+                      <div className="flex items-center justify-end gap-2">
+                        ⚙️ จัดการ
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/40">
+                  {filteredUsers.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-6 py-12 text-center">
+                        <div className="flex flex-col items-center justify-center">
+                          <div className="mb-4 h-20 w-20 rounded-full bg-[var(--color-rose)]/10 flex items-center justify-center text-3xl">
+                            👤
+                          </div>
+                          <div className="text-sm font-medium text-[var(--color-choco)]/60">
+                            {loading ? "กำลังโหลดข้อมูลผู้ใช้..." : "ไม่พบผู้ใช้ที่ตรงกับคำค้นหา"}
+                          </div>
+                          {!loading && search && (
+                            <div className="mt-2 text-xs text-[var(--color-choco)]/50">
+                              ลองเปลี่ยนคำค้นหาหรือล้างตัวกรองดู
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredUsers.map((user, idx) => {
+                      const isBusy = !!busy[user.id];
+                      const isEven = idx % 2 === 0;
+                      return (
+                        <tr 
+                          key={user.id} 
+                          className={`group transition-all duration-200 hover:bg-gradient-to-r hover:shadow-lg ${
+                            isEven 
+                              ? "bg-white/50 hover:from-white/80 hover:to-[#fff9f5]/60" 
+                              : "bg-[#fff7f0]/40 hover:from-[#fff9f5]/70 hover:to-white/50"
+                          } ${user.banned ? 'opacity-75' : ''}`}
+                        >
+                          <td className="px-6 py-5">
+                            <div className="flex items-center gap-3">
+                              <div className={`h-10 w-10 rounded-full flex items-center justify-center text-sm font-semibold ${
+                                user.role === 'admin' 
+                                  ? 'bg-gradient-to-br from-[#7cd1b8] to-[#5fb3a3] text-white' 
+                                  : 'bg-gradient-to-br from-[#f3d36b] to-[#e6c659] text-white'
+                              }`}>
+                                {user.role === 'admin' ? '👑' : '👤'}
+                              </div>
+                              <div>
+                                <div className="font-semibold text-[var(--color-choco)]">
+                                  {user.name || "ไม่ระบุชื่อ"}
+                                </div>
+                                {user.name && (
+                                  <div className="text-xs text-[var(--color-choco)]/60 mt-0.5">
+                                    ID: {user.id.slice(0, 8)}...
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-6 py-5">
+                            <div className="font-medium text-[var(--color-choco)]">{user.email}</div>
+                            <div className="text-xs text-[var(--color-choco)]/60 mt-0.5">
+                              {user.emailVerified ? '✅ ยืนยันแล้ว' : '⏳ รอยืนยัน'}
+                            </div>
+                          </td>
+                          <td className="px-6 py-5">
+                            <select
+                              className={`rounded-full border border-[var(--color-rose)]/30 bg-white/90 px-3 py-2 text-xs font-semibold shadow-sm transition-all duration-200 focus:border-[var(--color-rose)] focus:outline-none focus:shadow-md hover:shadow-md ${
+                                isBusy ? 'opacity-60 cursor-not-allowed' : 'hover:bg-white'
+                              }`}
+                              value={user.role}
+                              disabled={isBusy}
+                              onChange={(e) => handleRoleChange(user, e.target.value)}
+                            >
+                              {Object.entries(roleLabels).map(([value, label]) => (
+                                <option key={value} value={value}>
+                                  {label}
+                                </option>
+                              ))}
+                            </select>
+                          </td>
+                          <td className="px-6 py-5">
+                            <span
+                              className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold shadow-sm ${
+                                user.banned
+                                  ? "bg-gradient-to-r from-rose-100 to-rose-50 text-rose-600 border border-rose-200"
+                                  : "bg-gradient-to-r from-[#e7f8f0] to-[#d1f2e7] text-[var(--color-rose-dark)] border border-green-200"
+                              }`}
+                            >
+                              {user.banned ? "🔒 ถูกระงับ" : "✅ ปกติ"}
+                            </span>
+                          </td>
+                          <td className="px-6 py-5">
+                            <div className="text-xs text-[var(--color-choco)]/80 font-medium">
+                              {formatDate(user.createdAt)}
+                            </div>
+                          </td>
+                          <td className="px-6 py-5 text-right">
+                            <button
+                              type="button"
+                              onClick={() => toggleBan(user)}
+                              disabled={isBusy}
+                              className={`inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-xs font-semibold shadow-sm transition-all duration-200 ${
+                                user.banned
+                                  ? "bg-gradient-to-r from-[#7cd1b8]/20 to-[#5fb3a3]/10 text-[#0b7b59] border border-[#7cd1b8]/30 hover:from-[#7cd1b8]/30 hover:to-[#5fb3a3]/20 hover:shadow-md"
+                                  : "bg-gradient-to-r from-rose-100 to-rose-50 text-rose-600 border border-rose-200 hover:from-rose-200 hover:to-rose-100 hover:shadow-md"
+                              } ${isBusy ? "opacity-60 cursor-not-allowed" : "hover:scale-105 group-hover:shadow-lg"}`}
+                            >
+                              {isBusy ? (
+                                <>
+                                  <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                                  กำลังบันทึก...
+                                </>
+                              ) : user.banned ? (
+                                <>🔓 ปลดระงับ</>
+                              ) : (
+                                <>🔒 ระงับการใช้งาน</>
+                              )}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </section>
@@ -255,7 +432,7 @@ export default function AdminUsersPage() {
 function StatCard({ label, value, tone }) {
   return (
     <div
-      className={`rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-inner shadow-[rgba(240,200,105,0.19)] ${
+      className={`rounded-[1.5rem] border border-white/60 bg-white/70 p-4 text-center shadow-inner shadow-[#f5a25d1f] transition-all duration-200 hover:shadow-lg hover:scale-105 ${
         tone ? `bg-gradient-to-br ${tone}` : ""
       }`}
     >

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const roleLabels = {
+  admin: "ผู้ดูแลระบบ",
+  user: "ลูกค้าทั่วไป",
+};
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString("th-TH", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function extractErrorMessage(error) {
+  if (!error) return "เกิดข้อผิดพลาด";
+  if (typeof error === "string") return error;
+  if (error.message) return error.message;
+  if (error.error) return extractErrorMessage(error.error);
+  if (Array.isArray(error.formErrors) && error.formErrors.length > 0) {
+    return error.formErrors[0];
+  }
+  if (error.fieldErrors) {
+    const first = Object.values(error.fieldErrors)
+      .flat()
+      .find(Boolean);
+    if (first) return first;
+  }
+  return "เกิดข้อผิดพลาด";
+}
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState({});
+
+  async function load() {
+    setLoading(true);
+    setErr("");
+    try {
+      const res = await fetch("/api/admin/users", { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Load failed");
+      setUsers(Array.isArray(data?.users) ? data.users : []);
+    } catch (e) {
+      setErr(String(e.message || e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  function setBusyFor(id, value) {
+    setBusy((prev) => {
+      const next = { ...prev };
+      if (value) next[id] = true;
+      else delete next[id];
+      return next;
+    });
+  }
+
+  async function updateUser(id, payload, options = {}) {
+    const { confirmMessage } = options;
+    if (confirmMessage && !confirm(confirmMessage)) return;
+
+    setBusyFor(id, true);
+    try {
+      const res = await fetch(`/api/admin/users/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const message = extractErrorMessage(data?.error) || "บันทึกไม่สำเร็จ";
+        throw new Error(message);
+      }
+      if (data?.user) {
+        setUsers((prev) => prev.map((u) => (u.id === id ? data.user : u)));
+      }
+    } catch (e) {
+      alert(String(e.message || e));
+    } finally {
+      setBusyFor(id, false);
+    }
+  }
+
+  function handleRoleChange(user, nextRole) {
+    if (!nextRole || nextRole === user.role) return;
+    const confirmMessage =
+      nextRole === "admin"
+        ? `ยืนยันการปรับ ${user.email} เป็นผู้ดูแลระบบหรือไม่?`
+        : `ลดสิทธิ์ผู้ใช้ ${user.email} เป็นลูกค้าทั่วไป?`;
+    updateUser(user.id, { role: nextRole }, { confirmMessage });
+  }
+
+  function toggleBan(user) {
+    const willBan = !user.banned;
+    const confirmMessage = willBan
+      ? `ต้องการระงับการใช้งานของ ${user.email} หรือไม่?`
+      : `ปลดการระงับบัญชี ${user.email} หรือไม่?`;
+    updateUser(user.id, { banned: willBan }, { confirmMessage });
+  }
+
+  const filteredUsers = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return users;
+    return users.filter((u) => {
+      const haystack = `${u.name || ""} ${u.email}`.toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [search, users]);
+
+  const stats = useMemo(() => {
+    const total = users.length;
+    const adminCount = users.filter((u) => u.role === "admin").length;
+    const bannedCount = users.filter((u) => u.banned).length;
+    return { total, adminCount, bannedCount };
+  }, [users]);
+
+  return (
+    <div className="space-y-10">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการผู้ใช้งาน</h2>
+            <p className="mt-1 text-sm text-[var(--color-choco)]/70">
+              ตรวจสอบสถานะผู้ใช้ ปรับสิทธิ์การเข้าถึง และระงับบัญชีที่มีปัญหาได้จากหน้านี้
+            </p>
+          </div>
+          <div className="relative">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="ค้นหาชื่อหรืออีเมลผู้ใช้"
+              className="w-64 rounded-full border border-[var(--color-rose)]/30 bg-white/70 px-4 py-2 text-sm text-[var(--color-choco)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+            />
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-[var(--color-choco)]/50">
+              🔍
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-3">
+          <StatCard label="ผู้ใช้ทั้งหมด" value={stats.total} tone="from-[#f3d36b]/30 via-[#f7c68b]/20 to-transparent" />
+          <StatCard label="ผู้ดูแลระบบ" value={stats.adminCount} tone="from-[#7cd1b8]/30 via-[#f3d36b]/20 to-transparent" />
+          <StatCard label="ถูกระงับ" value={stats.bannedCount} tone="from-[#f5a25d]/30 via-[#f7c68b]/20 to-transparent" />
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f5a25d18]">
+        <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการผู้ใช้งาน</h3>
+            <p className="text-xs text-[var(--color-choco)]/60">
+              สามารถเปลี่ยนสิทธิ์การใช้งานหรือระงับบัญชีชั่วคราวได้จากตารางด้านล่าง
+            </p>
+          </div>
+          {loading && <span className="text-xs text-[var(--color-choco)]/60">กำลังโหลด...</span>}
+        </header>
+
+        {err ? (
+          <div className="px-6 py-8 text-center text-sm text-rose-600">{err}</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-white/60 text-sm text-[var(--color-choco)]">
+              <thead className="bg-[#fff5e4] text-[var(--color-choco)]/80">
+                <tr>
+                  <th className="px-6 py-3 text-left font-medium">ชื่อ</th>
+                  <th className="px-6 py-3 text-left font-medium">อีเมล</th>
+                  <th className="px-6 py-3 text-left font-medium">สิทธิ์</th>
+                  <th className="px-6 py-3 text-left font-medium">สถานะ</th>
+                  <th className="px-6 py-3 text-left font-medium">สร้างเมื่อ</th>
+                  <th className="px-6 py-3 text-right font-medium">จัดการ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredUsers.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-8 text-center text-sm text-[var(--color-choco)]/60">
+                      {loading ? "กำลังโหลดข้อมูลผู้ใช้..." : "ไม่พบผู้ใช้ที่ตรงกับคำค้นหา"}
+                    </td>
+                  </tr>
+                ) : (
+                  filteredUsers.map((user, idx) => {
+                    const isBusy = !!busy[user.id];
+                    return (
+                      <tr key={user.id} className={idx % 2 === 0 ? "bg-white" : "bg-[#fff7f0]"}>
+                        <td className="px-6 py-4 font-medium">{user.name || "-"}</td>
+                        <td className="px-6 py-4">{user.email}</td>
+                        <td className="px-6 py-4">
+                          <select
+                            className="rounded-full border border-[var(--color-rose)]/30 bg-white/80 px-3 py-1 text-xs font-semibold focus:border-[var(--color-rose)] focus:outline-none"
+                            value={user.role}
+                            disabled={isBusy}
+                            onChange={(e) => handleRoleChange(user, e.target.value)}
+                          >
+                            {Object.entries(roleLabels).map(([value, label]) => (
+                              <option key={value} value={value}>
+                                {label}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                        <td className="px-6 py-4">
+                          <span
+                            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                              user.banned
+                                ? "bg-rose-100 text-rose-600"
+                                : "bg-[#e7f8f0] text-[var(--color-rose-dark)]"
+                            }`}
+                          >
+                            {user.banned ? "ถูกระงับ" : "ปกติ"}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 text-xs text-[var(--color-choco)]/70">{formatDate(user.createdAt)}</td>
+                        <td className="px-6 py-4 text-right">
+                          <button
+                            type="button"
+                            onClick={() => toggleBan(user)}
+                            disabled={isBusy}
+                            className={`inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs font-semibold transition ${
+                              user.banned
+                                ? "bg-[#7cd1b8]/20 text-[#0b7b59] hover:bg-[#7cd1b8]/30"
+                                : "bg-rose-100 text-rose-600 hover:bg-rose-200"
+                            } ${isBusy ? "opacity-60" : ""}`}
+                          >
+                            {isBusy ? "กำลังบันทึก..." : user.banned ? "ปลดระงับ" : "ระงับการใช้งาน"}
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function StatCard({ label, value, tone }) {
+  return (
+    <div
+      className={`rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-inner shadow-[#f5a25d1f] ${
+        tone ? `bg-gradient-to-br ${tone}` : ""
+      }`}
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-choco)]/60">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-[var(--color-rose-dark)]">{value}</p>
+    </div>
+  );
+}

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -268,7 +268,7 @@ export default function AdminUsersPage() {
             <div className="hidden lg:block overflow-x-auto">
               <table className="min-w-full text-sm text-[var(--color-choco)]">
                 <thead>
-                  <tr className="bg-gradient-to-r from-[#fff5e4] to-[#fef7ed] border-b border-white/40">
+                  <tr className="bg-gradient-to-r rounded-b-3xl rounded-t-none  from-[#fff5e4] to-[#fef7ed] border-b border-white/40">
                     <th className="px-6 py-4 text-left font-semibold text-[var(--color-choco)]/90 tracking-wide">
                       <div className="flex items-center gap-2">
                         👤 ชื่อผู้ใช้
@@ -306,7 +306,7 @@ export default function AdminUsersPage() {
                     <tr>
                       <td colSpan={6} className="px-6 py-12 text-center">
                         <div className="flex flex-col items-center justify-center">
-                          <div className="mb-4 h-20 w-20 rounded-full bg-[var(--color-rose)]/10 flex items-center justify-center text-3xl">
+                          <div className="mb-4 h-20 w-20 c-full bg-[var(--color-rose)]/10 flex items-center justify-center text-3xl">
                             👤
                           </div>
                           <div className="text-sm font-medium text-[var(--color-choco)]/60">

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -130,7 +130,7 @@ export default function AdminUsersPage() {
 
   return (
     <div className="space-y-10">
-      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[#f5a25d14] backdrop-blur">
+      <section className="rounded-3xl border border-white/70 bg-white/80 p-6 shadow-lg shadow-[rgba(240,200,105,0.08)] backdrop-blur">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold text-[var(--color-rose-dark)]">จัดการผู้ใช้งาน</h2>
@@ -153,13 +153,13 @@ export default function AdminUsersPage() {
         </div>
 
         <div className="mt-6 grid gap-4 sm:grid-cols-3">
-          <StatCard label="ผู้ใช้ทั้งหมด" value={stats.total} tone="from-[#f3d36b]/30 via-[#f7c68b]/20 to-transparent" />
-          <StatCard label="ผู้ดูแลระบบ" value={stats.adminCount} tone="from-[#7cd1b8]/30 via-[#f3d36b]/20 to-transparent" />
-          <StatCard label="ถูกระงับ" value={stats.bannedCount} tone="from-[#f5a25d]/30 via-[#f7c68b]/20 to-transparent" />
+          <StatCard label="ผู้ใช้ทั้งหมด" value={stats.total} tone="from-[#f3d36b]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
+          <StatCard label="ผู้ดูแลระบบ" value={stats.adminCount} tone="from-[#7cd1b8]/30 via-[var(--color-gold)]/20 to-transparent" />
+          <StatCard label="ถูกระงับ" value={stats.bannedCount} tone="from-[var(--color-rose)]/30 via-[var(--color-rose-dark)]/20 to-transparent" />
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[#f5a25d18]">
+      <section className="rounded-3xl border border-white/70 bg-white/70 shadow-xl shadow-[rgba(240,200,105,0.09)]">
         <header className="flex flex-col gap-2 border-b border-white/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-[var(--color-choco)]">รายการผู้ใช้งาน</h3>
@@ -255,7 +255,7 @@ export default function AdminUsersPage() {
 function StatCard({ label, value, tone }) {
   return (
     <div
-      className={`rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-inner shadow-[#f5a25d1f] ${
+      className={`rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-inner shadow-[rgba(240,200,105,0.19)] ${
         tone ? `bg-gradient-to-br ${tone}` : ""
       }`}
     >

--- a/app/api/admin/users/[id]/route.js
+++ b/app/api/admin/users/[id]/route.js
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { Types } from "mongoose";
+import { z } from "zod";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { User } from "@/models/User";
+
+const schema = z
+  .object({
+    role: z.enum(["user", "admin"]).optional(),
+    banned: z.boolean().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "No changes provided",
+    path: ["role"],
+  });
+
+function serializeUser(u) {
+  return {
+    id: String(u._id),
+    name: u.name || "",
+    email: u.email,
+    role: u.role || "user",
+    banned: !!u.banned,
+    createdAt: u.createdAt,
+    updatedAt: u.updatedAt,
+  };
+}
+
+export async function PATCH(req, { params }) {
+  const { id } = await params;
+
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const updates = parsed.data;
+
+  if (updates.role && session.user.id === id && updates.role !== "admin") {
+    return NextResponse.json({ error: "ไม่สามารถลดสิทธิ์ตัวเองได้" }, { status: 400 });
+  }
+  if (typeof updates.banned === "boolean" && updates.banned && session.user.id === id) {
+    return NextResponse.json({ error: "ไม่สามารถแบนบัญชีของตัวเองได้" }, { status: 400 });
+  }
+
+  await connectToDatabase();
+  const updated = await User.findByIdAndUpdate(id, updates, { new: true }).lean();
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ user: serializeUser(updated) });
+}

--- a/app/api/admin/users/route.js
+++ b/app/api/admin/users/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { User } from "@/models/User";
+
+function serializeUser(u) {
+  return {
+    id: String(u._id),
+    name: u.name || "",
+    email: u.email,
+    role: u.role || "user",
+    banned: !!u.banned,
+    createdAt: u.createdAt,
+    updatedAt: u.updatedAt,
+  };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await connectToDatabase();
+  const users = await User.find({}, null, { sort: { createdAt: -1 } }).lean();
+
+  return NextResponse.json({
+    users: users.map(serializeUser),
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,13 +7,15 @@
   --color-cream: #1b0606;
   --color-cream-soft: #240909;
   --color-rose: #f0c869;
-  --color-rose-dark: #c18a1d;
+  --color-rose-dark: #f5cf7a;
   --color-gold: #f8e6b4;
   --color-text: #f6ede0;
-  --color-choco: #2b100f;
+  --color-choco: #f6ede0;
   --color-burgundy: #3a1010;
   --color-burgundy-soft: #4c1912;
   --color-burgundy-dark: #140202;
+  --surface-strong: rgba(58, 16, 16, 0.78);
+  --surface-soft: rgba(58, 16, 16, 0.62);
   --layout-max: 1200px;
 }
 
@@ -58,11 +60,26 @@ label {
   textarea,
   select {
     background-color: rgba(58, 16, 16, 0.65);
-    color: var(--color-choco);
+    color: var(--color-text);
   }
 
   input::placeholder,
   textarea::placeholder {
     color: rgba(248, 230, 180, 0.6);
   }
+}
+
+:is(.bg-white, .bg-white\/95, .bg-white\/90, .bg-white\/85) {
+  background-color: var(--surface-strong) !important;
+  color: var(--color-text) !important;
+  border-color: rgba(240, 200, 105, 0.22) !important;
+  box-shadow: 0 22px 46px -28px rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(14px);
+}
+
+:is(.bg-white\/80, .bg-white\/70, .bg-white\/60) {
+  background-color: var(--surface-soft) !important;
+  color: var(--color-text) !important;
+  border-color: rgba(240, 200, 105, 0.18) !important;
+  backdrop-filter: blur(12px);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,11 +4,16 @@
 @tailwind utilities;
 
 :root {
-  --color-cream: #fffaf2;
-  --color-rose: #f5a25d;
-  --color-rose-dark: #d97a2c;
-  --color-gold: #f3d36b;
-  --color-choco: #5e4029;
+  --color-cream: #1b0606;
+  --color-cream-soft: #240909;
+  --color-rose: #f0c869;
+  --color-rose-dark: #c18a1d;
+  --color-gold: #f8e6b4;
+  --color-text: #f6ede0;
+  --color-choco: #2b100f;
+  --color-burgundy: #3a1010;
+  --color-burgundy-soft: #4c1912;
+  --color-burgundy-dark: #140202;
   --layout-max: 1200px;
 }
 
@@ -19,8 +24,8 @@ body {
 
 body {
   margin: 0;
-  background: var(--color-cream);
-  color: var(--color-choco);
+  background: radial-gradient(circle at top, #2b0a0a 0%, var(--color-cream) 55%, var(--color-burgundy-dark) 100%);
+  color: var(--color-text);
   font-family: "Poppins", "Prompt", "Kanit", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -33,9 +38,31 @@ a:hover {
 } */
 
 ::selection {
-  background: rgba(245, 162, 93, 0.25);
+  background: rgba(240, 200, 105, 0.35);
 }
 
 label {
-  color: rgba(79, 43, 29, 0.85);
+  color: rgba(248, 230, 180, 0.85);
+}
+
+@layer base {
+  :root {
+    color-scheme: dark;
+  }
+
+  * {
+    border-color: rgba(240, 200, 105, 0.2);
+  }
+
+  input,
+  textarea,
+  select {
+    background-color: rgba(58, 16, 16, 0.65);
+    color: var(--color-choco);
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: rgba(248, 230, 180, 0.6);
+  }
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -8,7 +8,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="th">
-      <body className="min-h-screen bg-[var(--color-cream)] text-[var(--color-choco)]">
+      <body className="min-h-screen text-[var(--color-text)] antialiased">
         {children}
       </body>
     </html>

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -27,7 +27,7 @@ export default function AddToCartButton({ product }) {
 
   return (
     <button
-      className="px-4 py-2 rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f7c68b] text-white text-sm font-semibold shadow-lg shadow-[#f5a25d33] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+      className="px-4 py-2 rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] text-[var(--color-burgundy-dark)] text-sm font-semibold shadow-lg shadow-[rgba(240,200,105,0.33)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
       onClick={handleClick}
     >
       เพิ่มลงตะกร้า

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -24,7 +24,7 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="mt-20 bg-gradient-to-br from-[#ffd5b5] via-[#ffe4d6] to-[#ffd6e8] text-[var(--color-choco)]">
+    <footer className="mt-20 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[var(--color-burgundy-soft)] text-[var(--color-gold)]">
       <div className="relative">
         {/* <div className="absolute -top-6 left-6 hidden rotate-6 text-5xl opacity-40 md:block">
           🥐
@@ -35,19 +35,19 @@ export default function Footer() {
         <div className="relative mx-auto flex max-w-screen-xl flex-col gap-12 px-6 py-14">
           <div className="grid gap-10 lg:grid-cols-4">
             <div className="lg:col-span-2">
-              <h2 className="text-2xl font-extrabold text-[var(--color-rose-dark)]">
+              <h2 className="text-2xl font-extrabold text-[var(--color-rose)]">
                 Sweet Cravings Bakery
               </h2>
-              <p className="mt-4 max-w-xl text-sm leading-relaxed text-[var(--color-choco)]/80">
+              <p className="mt-4 max-w-xl text-sm leading-relaxed text-[var(--color-gold)]/80">
                 อบขนมสดใหม่ทุกเช้า ส่งต่อความอบอุ่นแบบโฮมเมดถึงมือคุณ ทั้งครัวซองต์
                 ชีสเค้ก บราวนี่ และเครื่องดื่มซิกเนเจอร์ที่เข้ากับทุกช่วงเวลา
               </p>
-              <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-[var(--color-choco)]/80">
+              <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-[var(--color-gold)]/80">
                 {socials.map(({ href, label }) => (
                   <a
                     key={label}
                     href={href}
-                    className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 font-medium shadow-sm transition hover:bg-white"
+                    className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-2 font-medium text-[var(--color-gold)] shadow-sm transition hover:bg-[var(--color-burgundy)]"
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -61,12 +61,12 @@ export default function Footer() {
             <div className="grid gap-10 sm:grid-cols-2 lg:col-span-2">
               <div>
                 <h3 className="text-lg font-semibold text-[var(--color-rose)]">เมนูด่วน</h3>
-                <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
+                <ul className="mt-4 space-y-3 text-sm text-[var(--color-gold)]/80">
                   {customerLinks.map(({ href, label }) => (
                     <li key={href}>
                       <Link
                         href={href}
-                        className="transition hover:text-[var(--color-rose-dark)]"
+                        className="transition hover:text-[var(--color-rose)]"
                       >
                         {label}
                       </Link>
@@ -77,12 +77,12 @@ export default function Footer() {
 
               <div>
                 <h3 className="text-lg font-semibold text-[var(--color-rose)]">บริการ & ข้อมูล</h3>
-                <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
+                <ul className="mt-4 space-y-3 text-sm text-[var(--color-gold)]/80">
                   {serviceLinks.map(({ href, label }) => (
                     <li key={href}>
                       <Link
                         href={href}
-                        className="transition hover:text-[var(--color-rose-dark)]"
+                        className="transition hover:text-[var(--color-rose)]"
                       >
                         {label}
                       </Link>
@@ -94,45 +94,42 @@ export default function Footer() {
           </div>
 
           <div className="grid gap-6 lg:grid-cols-3">
-            <div className="rounded-3xl bg-white/70 p-6 shadow-sm backdrop-blur">
+            <div className="rounded-3xl border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/70 p-6 shadow-sm shadow-black/30 backdrop-blur">
               <h3 className="text-lg font-semibold text-[var(--color-rose)]">ติดต่อเรา</h3>
-              <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
+              <ul className="mt-4 space-y-3 text-sm text-[var(--color-gold)]/85">
                 <li>
-                  <span className="font-medium text-[var(--color-choco)]">โทร:</span>{" "}
-                  <a href="tel:021234567" className="hover:text-[var(--color-rose-dark)]">
+                  <span className="font-medium text-[var(--color-gold)]">โทร:</span>{" "}
+                  <a href="tel:021234567" className="hover:text-[var(--color-rose)]">
                     02-123-4567
                   </a>
                 </li>
                 <li>
-                  <span className="font-medium text-[var(--color-choco)]">อีเมล:</span>{" "}
-                  <a
-                    href="mailto:hello@sweetcravings.co"
-                    className="hover:text-[var(--color-rose-dark)]"
-                  >
+                  <span className="font-medium text-[var(--color-gold)]">อีเมล:</span>{" "}
+                  <a href="mailto:hello@sweetcravings.co" className="hover:text-[var(--color-rose)]">
                     hello@sweetcravings.co
                   </a>
                 </li>
                 <li>
-                  <span className="font-medium text-[var(--color-choco)]">ที่อยู่หน้าร้าน:</span>
-                  <p className="mt-1 leading-relaxed">
+                  <span className="font-medium text-[var(--color-gold)]">ที่อยู่หน้าร้าน:</span>
+                  <p className="mt-1 leading-relaxed text-[var(--color-gold)]/80">
                     88/8 ซอยหวานหอม แขวงขนมหวาน เขตวัฒนา กรุงเทพฯ 10110
                   </p>
                 </li>
               </ul>
             </div>
 
-            <div className="rounded-3xl bg-white/70 p-6 shadow-sm backdrop-blur">
+            <div className="rounded-3xl border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/70 p-6 shadow-sm shadow-black/30 backdrop-blur">
               <h3 className="text-lg font-semibold text-[var(--color-rose)]">เวลาเปิดให้บริการ</h3>
-              <ul className="mt-4 space-y-3 text-sm text-[var(--color-choco)]/80">
+              <ul className="mt-4 space-y-3 text-sm text-[var(--color-gold)]/85">
                 <li>จันทร์ - ศุกร์: 07:30 - 18:30 น.</li>
                 <li>เสาร์ - อาทิตย์: 08:00 - 19:30 น.</li>
                 <li>บริการจัดส่งในเขตกรุงเทพฯ และปริมณฑล</li>
               </ul>
             </div>
 
-            <div className="rounded-3xl bg-white/70 p-6 shadow-sm backdrop-blur">
+            <div className="rounded-3xl border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/70 p-6 shadow-sm shadow-black/30 backdrop-blur">
               <h3 className="text-lg font-semibold text-[var(--color-rose)]">รับข่าวสารสุดพิเศษ</h3>
-              <p className="mt-4 text-sm text-[var(--color-choco)]/80">
+              <p className="mt-4 text-sm text-[var(--color-gold)]/85">
                 ลงทะเบียนเพื่อรับโปรโมชั่นเมนูใหม่ สูตรลับจากเชฟ และเวิร์กช็อปอบขนมก่อนใคร
               </p>
               <form className="mt-5 flex flex-col gap-3 sm:flex-row">
@@ -143,22 +140,22 @@ export default function Footer() {
                   id="newsletter"
                   type="email"
                   placeholder="your@email.com"
-                  className="w-full rounded-full border border-white/60 bg-white/90 px-4 py-2 text-sm shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
+                  className="w-full rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/60 px-4 py-2 text-sm text-[var(--color-gold)] shadow-inner focus:border-[var(--color-rose)] focus:outline-none"
                 />
                 <button
                   type="button"
-                  className="rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-[var(--color-rose-dark)]"
+                  className="rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/40 transition hover:bg-[var(--color-rose-dark)]"
                 >
                   ติดตาม
                 </button>
               </form>
-              <p className="mt-3 text-xs text-[var(--color-choco)]/60">
+              <p className="mt-3 text-xs text-[var(--color-gold)]/60">
                 *เราจะส่งอีเมลไม่เกินสัปดาห์ละ 1 ครั้ง และคุณสามารถยกเลิกได้ทุกเมื่อ
               </p>
             </div>
           </div>
 
-          <div className="flex flex-col items-start justify-between gap-4 border-t border-white/60 pt-6 text-xs text-[var(--color-choco)]/70 sm:flex-row">
+          <div className="flex flex-col items-start justify-between gap-4 border-t border-[var(--color-rose)]/20 pt-6 text-xs text-[var(--color-gold)]/70 sm:flex-row">
             <p>© {year} Sweet Cravings Bakery. All rights reserved.</p>
             <div className="flex flex-wrap gap-4">
               {/* <Link href="/privacy" className="hover:text-[var(--color-rose-dark)]">
@@ -171,7 +168,7 @@ export default function Footer() {
                 href="https://maps.google.com/?q=Sweet+Cravings+Bakery"
                 target="_blank"
                 rel="noreferrer"
-                className="hover:text-[var(--color-rose-dark)]"
+                className="hover:text-[var(--color-rose)]"
               >
                 เปิดดูแผนที่
               </a>

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -63,10 +63,10 @@ export default function NavBar() {
       <Link
         key={item.href}
         href={targetHref}
-        className={`flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/30 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:w-auto md:justify-center ${
+        className={`flex w-full items-center justify-between gap-3 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:w-auto md:justify-center ${
           active
-            ? "bg-white/80 text-[var(--color-rose)] shadow"
-            : "text-[var(--color-choco)] hover:text-[var(--color-rose)]"
+            ? "bg-[var(--color-burgundy)]/80 text-[var(--color-rose)] shadow-lg shadow-black/30"
+            : "text-[var(--color-gold)]/80 hover:text-[var(--color-rose)]"
         }`}
         onClick={() => setMenuOpen(false)}
       >
@@ -91,37 +91,43 @@ export default function NavBar() {
   };
 
   return (
-    <header className="sticky top-0 z-30 bg-[var(--color-cream)]/80 backdrop-blur">
-      <div className="hidden md:flex items-center justify-between border-b border-white/50 px-6 py-2 text-xs text-[var(--color-choco)]/80 max-w-screen-xl mx-auto">
+    <header className="sticky top-0 z-30 bg-[var(--color-burgundy-dark)]/60 backdrop-blur">
+      <div className="hidden md:flex items-center justify-between border-b border-[var(--color-rose)]/15 px-6 py-2 text-xs text-[var(--color-gold)]/80 max-w-screen-xl mx-auto">
         <span className="tracking-wide">อบสดใหม่ทุกวัน • ส่งฟรีในเมืองเมื่อสั่งครบ ฿800</span>
         <a
           href="tel:021234567"
-          className="font-medium transition-colors hover:text-[var(--color-rose)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+          className="font-medium text-[var(--color-gold)]/80 transition-colors hover:text-[var(--color-rose)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
         >
           โทร. 061-267-4523
         </a>
       </div>
 
-      <nav className="bg-gradient-to-r from-[#fff5e6] via-[#fde7b8] to-[#f6c08c] shadow-md">
-        <div className="max-w-screen-xl mx-auto px-4 sm:px-6">
-          <div className="flex items-center justify-between gap-6 py-4">
+      <nav className="shadow-[0_20px_40px_-20px_rgba(0,0,0,0.6)]">
+        <div className="bg-gradient-to-r from-[var(--color-burgundy-soft)] via-[var(--color-cream-soft)] to-[var(--color-burgundy-soft)]">
+          <div className="max-w-screen-xl mx-auto flex items-center justify-between gap-6 px-4 py-4 sm:px-6">
             <Link
               href="/"
-              className="group flex items-center gap-3 rounded-full bg-white/70 px-3 py-1 transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/30"
+              className="group flex items-center gap-3 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/70 px-3 py-1 text-[var(--color-gold)] transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
             >
               {/* <Image
                className="h-10 w-10 rounded-full bg-white/90 shadow-inner flex items-center justify-center text-xl transition-transform group-hover:scale-105">
                 🥐
               </Image> */}
 
-              <Image src="/images/logo.png" alt="logo" width={100} height={100} className="h-10 w-10 rounded-full bg-white/90 shadow-inner flex items-center justify-center text-xl transition-transform group-hover:scale-105" />
-              <span className="text-xl sm:text-2xl font-extrabold text-[var(--color-rose-dark)] tracking-tight">
+              <Image
+                src="/images/logo.png"
+                alt="logo"
+                width={100}
+                height={100}
+                className="h-10 w-10 rounded-full border border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/80 shadow-inner flex items-center justify-center text-xl transition-transform group-hover:scale-105"
+              />
+              <span className="text-xl sm:text-2xl font-extrabold text-[var(--color-rose)] tracking-tight">
                Steaming Bun
               </span>
             </Link>
 
             <button
-              className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/80 text-[var(--color-rose-dark)] shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
+              className="md:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/80 text-[var(--color-rose)] shadow transition hover:bg-[var(--color-burgundy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
               onClick={() => setMenuOpen((v) => !v)}
               aria-label="Toggle menu"
               type="button"
@@ -151,24 +157,24 @@ export default function NavBar() {
             </button>
 
             <div className="hidden md:flex items-center gap-4">
-              <div className="flex items-center gap-2 rounded-full bg-white/70 px-2 py-1 shadow-inner">
-              {navItems.map((item) => link(item))}
+              <div className="flex items-center gap-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-2 py-1 shadow-inner shadow-black/20">
+                {navItems.map((item) => link(item))}
               </div>
               {status === "loading" && (
-                <span className="text-xs text-[var(--color-choco)]/70">กำลังโหลด...</span>
+                <span className="text-xs text-[var(--color-gold)]/70">กำลังโหลด...</span>
               )}
 
               {status === "unauthenticated" && (
                 <div className="flex items-center gap-2">
                   <Link
                     href="/login"
-                    className="px-4 py-2 rounded-full text-sm font-medium bg-white/80 text-[var(--color-rose-dark)] shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
+                    className="px-4 py-2 rounded-full text-sm font-medium text-[var(--color-rose)] bg-[var(--color-burgundy)]/70 shadow transition hover:bg-[var(--color-burgundy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
                   >
                     เข้าสู่ระบบ
                   </Link>
                   <Link
                     href="/register"
-                    className="px-4 py-2 rounded-full text-sm font-medium text-white bg-[var(--color-rose)] shadow-lg transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+                    className="px-4 py-2 rounded-full text-sm font-semibold text-[var(--color-burgundy-dark)] bg-[var(--color-rose)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
                   >
                     สมัครสมาชิก
                   </Link>
@@ -180,18 +186,20 @@ export default function NavBar() {
                   {session?.user?.role === "admin" && (
                     <Link
                       href="/admin"
-                      className="px-4 py-2 rounded-full bg-white/80 text-[var(--color-rose-dark)] shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
+                      className="px-4 py-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 text-[var(--color-rose)] shadow transition hover:bg-[var(--color-burgundy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
                     >
                       จัดการร้าน
                     </Link>
                   )}
-                  <span className="px-5 py-2 rounded-full bg-[#f8e9d8] text-[var(--color-choco)]/80 font-medium shadow-inner"
-      style={{ boxShadow: "inset 3px 3px 6px rgba(0,0,0,0.2), inset -3px -3px 6px rgba(255,255,255,0.7)" }}>
-  {session?.user?.name || session?.user?.email}
-</span>
+                  <span
+                    className="px-5 py-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/50 text-[var(--color-gold)]/90 font-medium shadow-inner"
+                    style={{ boxShadow: "inset 3px 3px 6px rgba(0,0,0,0.25), inset -3px -3px 6px rgba(240,200,105,0.35)" }}
+                  >
+                    {session?.user?.name || session?.user?.email}
+                  </span>
                   <button
                     onClick={() => signOut({ callbackUrl: "/" })}
-                    className="px-4 py-2 rounded-full font-medium text-white bg-red-400 shadow transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
+                    className="px-4 py-2 rounded-full font-medium text-white bg-red-500/80 shadow transition hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
                   >
                     ออกจากระบบ
                   </button>
@@ -212,7 +220,7 @@ export default function NavBar() {
 
         <div
           id="mobile-menu"
-          className={`md:hidden fixed inset-x-4 top-[5.5rem] z-30 origin-top rounded-3xl bg-white/90 p-6 text-sm text-[var(--color-choco)] shadow-2xl backdrop-blur transition-transform duration-200 ${
+          className={`md:hidden fixed inset-x-4 top-[5.5rem] z-30 origin-top rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/95 p-6 text-sm text-[var(--color-gold)] shadow-2xl shadow-black/50 backdrop-blur transition-transform duration-200 ${
             menuOpen ? "scale-100 opacity-100" : "pointer-events-none scale-95 opacity-0"
           }`}
         >
@@ -223,19 +231,19 @@ export default function NavBar() {
               </div>
             ))}
             {status === "loading" && (
-              <span className="text-xs text-[var(--color-choco)]/70">กำลังโหลด...</span>
+              <span className="text-xs text-[var(--color-gold)]/70">กำลังโหลด...</span>
             )}
             {status === "unauthenticated" && (
               <div className="flex flex-col gap-2">
                 <Link
                   href="/login"
-                  className="px-4 py-2 rounded-full font-medium bg-white text-[var(--color-rose-dark)] shadow transition hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/30"
+                  className="px-4 py-2 rounded-full font-medium text-[var(--color-rose)] bg-[var(--color-burgundy)]/80 shadow transition hover:bg-[var(--color-burgundy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
                 >
                   เข้าสู่ระบบ
                 </Link>
                 <Link
                   href="/register"
-                  className="px-4 py-2 rounded-full font-medium text-white bg-[var(--color-rose)] shadow transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
+                  className="px-4 py-2 rounded-full font-semibold text-[var(--color-burgundy-dark)] bg-[var(--color-rose)] shadow transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
                 >
                   สมัครสมาชิก
                 </Link>
@@ -246,18 +254,18 @@ export default function NavBar() {
                 {session?.user?.role === "admin" && (
                   <Link
                     href="/admin"
-                    className="px-4 py-2 rounded-full font-medium bg-white text-[var(--color-rose-dark)] shadow transition hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/30"
+                    className="px-4 py-2 rounded-full font-medium text-[var(--color-rose)] bg-[var(--color-burgundy)]/80 shadow transition hover:bg-[var(--color-burgundy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-rose)]/40"
                   >
                     จัดการร้าน
                   </Link>
                 )}
-                <span className="px-5 py-2 rounded-full bg-[#f8e9d8] text-[var(--color-choco)]/80 font-medium shadow-inner"
-      style={{ boxShadow: "inset 3px 3px 6px rgba(0,0,0,0.2), inset -3px -3px 6px rgba(255,255,255,0.7)" }}>
+                <span className="px-5 py-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/60 text-[var(--color-gold)]/90 font-medium shadow-inner"
+      style={{ boxShadow: "inset 3px 3px 6px rgba(0,0,0,0.25), inset -3px -3px 6px rgba(240,200,105,0.35)" }}>
   {session?.user?.name || session?.user?.email}
 </span>
                 <button
                   onClick={() => signOut({ callbackUrl: "/" })}
-                  className="px-4 py-2 rounded-full font-medium text-white bg-red-400 shadow transition hover:bg-[var(--color-rose-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
+                  className="px-4 py-2 rounded-full font-medium text-white bg-red-500/80 shadow transition hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
                 >
                   ออกจากระบบ
                 </button>

--- a/components/QrBox.jsx
+++ b/components/QrBox.jsx
@@ -64,21 +64,21 @@ export default function QrBox({ payload, amount, title = "สแกนจ่า�
 }
 
   return (
-    <div className="rounded-3xl bg-white p-6 text-center shadow-lg shadow-[#f5a25d1a]">
+    <div className="rounded-3xl bg-white p-6 text-center shadow-lg shadow-[rgba(240,200,105,0.1)]">
       <div className="text-lg font-semibold text-[var(--color-choco)]">{title}</div>
       <div className="mt-1 text-sm text-[var(--color-choco)]/70">จำนวนเงิน: ฿{amount}</div>
 
       <div className="mt-4 flex items-center justify-center">
-        <canvas ref={canvasRef} className="rounded-2xl border border-[#f4c689]/40 bg-white p-3" />
+        <canvas ref={canvasRef} className="rounded-2xl border border-[var(--color-rose)]/30 bg-white p-3" />
       </div>
 
       <div className="mt-4 space-y-2 text-left">
-  {/* <div className="rounded-2xl border border-[#f4c689]/40 bg-[#fff6ed] p-3 text-xs text-[var(--color-choco)]/80 break-all">
+  {/* <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[rgba(240,200,105,0.12)] p-3 text-xs text-[var(--color-choco)]/80 break-all">
     {payload}
   </div> */}
 
   <button
-    className="w-full rounded-full bg-gradient-to-r from-[#f5a25d] to-[#f7c68b] px-4 py-2 text-sm font-semibold text-white shadow shadow-[#f5a25d33] transition hover:shadow-md"
+    className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-4 py-2 text-sm font-semibold text-white shadow shadow-[rgba(240,200,105,0.33)] transition hover:shadow-md"
     onClick={saveQrCode}
     type="button"
   >

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -33,8 +33,8 @@ export default function AdminSidebar() {
             href={it.href}
             className={`group flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold tracking-wide transition ${
               active
-                ? "bg-white text-[var(--color-rose-dark)] shadow-lg shadow-[#f5a25d33]"
-                : "text-white/80 hover:bg-white/15 hover:text-white"
+                ? "border border-[var(--color-rose)]/40 bg-[var(--color-burgundy-dark)]/80 text-[var(--color-rose)] shadow-lg shadow-black/30"
+                : "text-[var(--color-gold)]/80 hover:bg-[var(--color-burgundy)]/60 hover:text-[var(--color-gold)]"
             }`}
           >
             <span className="text-base transition-transform group-hover:scale-110">{it.icon}</span>
@@ -49,7 +49,7 @@ export default function AdminSidebar() {
     <>
       <button
         type="button"
-        className="fixed left-4 top-4 z-40 inline-flex items-center gap-2 rounded-full border border-white/40 bg-[var(--color-rose)]/90 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-[#f5a25d33] backdrop-blur transition hover:bg-[var(--color-rose)] lg:hidden"
+        className="fixed left-4 top-4 z-40 inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy)]/80 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] shadow-lg shadow-black/30 backdrop-blur transition hover:bg-[var(--color-burgundy)] lg:hidden"
         onClick={() => setOpen(true)}
         aria-expanded={open}
         aria-controls="admin-sidebar"
@@ -66,7 +66,7 @@ export default function AdminSidebar() {
 
       <aside
         id="admin-sidebar"
-        className={`fixed inset-y-0 left-0 z-50 w-72 origin-left transform bg-gradient-to-b from-[#f5a25d] via-[#f7c68b] to-[#f3d36b] text-white shadow-[12px_0_40px_-16px_#f5a25d90] transition-transform duration-300 ease-in-out lg:static lg:block lg:h-auto lg:w-72 lg:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-50 w-72 origin-left transform bg-gradient-to-b from-[var(--color-burgundy)] via-[var(--color-burgundy-dark)] to-[#090101] text-[var(--color-gold)] shadow-[12px_0_40px_-16px_rgba(0,0,0,0.6)] transition-transform duration-300 ease-in-out lg:static lg:block lg:h-auto lg:w-72 lg:translate-x-0 ${
           open ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
         }`}
       >
@@ -77,7 +77,7 @@ export default function AdminSidebar() {
           </span>
           <button
             type="button"
-            className="rounded-full border border-white/30 px-2 py-1 text-xs text-white/80 transition hover:border-white hover:text-white lg:hidden"
+            className="rounded-full border border-[var(--color-rose)]/30 px-2 py-1 text-xs text-[var(--color-gold)]/80 transition hover:border-[var(--color-rose)] hover:text-[var(--color-rose)] lg:hidden"
             onClick={() => setOpen(false)}
           >
             ปิด
@@ -85,8 +85,8 @@ export default function AdminSidebar() {
         </div>
 
         <div className="px-6 pb-6">
-          <div className="rounded-2xl bg-white/15 p-4 text-xs text-white/80 shadow-inner">
-            <p className="font-semibold text-white">สวัสดีผู้ดูแลร้าน!</p>
+          <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/70 p-4 text-xs text-[var(--color-gold)]/80 shadow-inner">
+            <p className="font-semibold text-[var(--color-rose)]">สวัสดีผู้ดูแลร้าน!</p>
             <p className="mt-1 leading-relaxed">
               จัดการสินค้า ติดตามคำสั่งซื้อ และปรับโปรโมชั่นได้จากศูนย์ควบคุมนี้
             </p>
@@ -95,16 +95,16 @@ export default function AdminSidebar() {
 
         <nav className="space-y-2 px-4 pb-8">{nav}</nav>
 
-        <div className="mt-auto space-y-3 px-6 pb-10 text-xs text-white/70">
-          <div className="rounded-2xl border border-white/20 bg-white/10 p-3 shadow-inner">
-            <p className="font-semibold text-white">เคล็ดลับวันนี้</p>
+        <div className="mt-auto space-y-3 px-6 pb-10 text-xs text-[var(--color-gold)]/70">
+          <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/70 p-3 shadow-inner">
+            <p className="font-semibold text-[var(--color-rose)]">เคล็ดลับวันนี้</p>
             <p className="mt-1 leading-relaxed">
               ใช้ส่วนลดช่วงเทศกาลเพื่อดึงลูกค้าใหม่ๆ และกระตุ้นยอดซื้อซ้ำ
             </p>
           </div>
           <a
             href="/"
-            className="inline-flex w-full items-center justify-center rounded-full bg-white/20 px-4 py-2 font-semibold text-white transition hover:bg-white/30"
+            className="inline-flex w-full items-center justify-center rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-2 font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)]"
           >
             ↩︎ กลับหน้าร้าน
           </a>

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -7,6 +7,7 @@ const items = [
   { href: "/admin", label: "แดชบอร์ด", icon: "📊" },
   { href: "/admin/products", label: "จัดการสินค้า", icon: "🧁" },
   { href: "/admin/orders", label: "คำสั่งซื้อ", icon: "🧾" },
+  { href: "/admin/users", label: "ผู้ใช้งาน", icon: "👥" },
   { href: "/admin/coupons", label: "คูปอง", icon: "🎟️" },
 ];
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,7 +17,14 @@ export const authOptions = {
         if (!user) return null;
         const ok = await bcrypt.compare(String(creds?.password), user.passwordHash || "");
         if (!ok) return null;
-        return { id: String(user._id), email: user.email, name: user.name, role: user.role };
+        if (user.banned) throw new Error("บัญชีนี้ถูกระงับการใช้งาน");
+        return {
+          id: String(user._id),
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          banned: user.banned,
+        };
       },
     }),
   ],
@@ -26,12 +33,31 @@ export const authOptions = {
       if (user) {
         token.role = user.role || "user";
         token.id = user.id;
+        token.banned = !!user.banned;
+        return token;
       }
+
+      if (!token?.id) return token;
+
+      await connectToDatabase();
+      const current = await User.findById(token.id).lean();
+      if (!current) {
+        token.banned = true;
+        token.role = "user";
+        return token;
+      }
+      token.role = current.role || "user";
+      token.banned = !!current.banned;
+      token.name = current.name || token.name;
       return token;
     },
     async session({ session, token }) {
+      if (token?.banned) {
+        return null;
+      }
       session.user.role = token.role;
       session.user.id = token.id || token.sub;
+      session.user.banned = !!token.banned;
       return session;
     },
   },

--- a/models/User.js
+++ b/models/User.js
@@ -6,6 +6,7 @@ const UserSchema = new Schema(
     email: { type: String, unique: true, index: true },
     passwordHash: String,
     role: { type: String, enum: ["user", "admin"], default: "user", index: true },
+    banned: { type: Boolean, default: false, index: true },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- add an admin "ผู้ใช้งาน" page with search, stats, role switching, and ban/unban controls
- expose admin-only API endpoints to list users and update their role or ban status with validation
- persist a banned flag on users and enforce it in NextAuth so suspended accounts cannot keep an active session

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b92b02e4832db8bf7b11b450dd1b