### PR TITLE
feat: replace admin alerts with popup dialogs

### DIFF
--- a/app/admin/coupons/page.jsx
+++ b/app/admin/coupons/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
 
 /* ---------- Shared UI (match Products page) ---------- */
 function StatBubble({ label, value, color }) {
@@ -82,6 +83,7 @@ export default function AdminCouponsPage() {
   const [form, setForm] = useState(emptyCoupon);
   const [search, setSearch] = useState("");
   const [saving, setSaving] = useState(false);
+  const popup = useAdminPopup();
 
   async function load() {
     setLoading(true);
@@ -144,7 +146,10 @@ export default function AdminCouponsPage() {
     const data = await res.json();
     setSaving(false);
     if (!res.ok) {
-      alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ");
+      await popup.alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     setEditing(null);
@@ -152,11 +157,20 @@ export default function AdminCouponsPage() {
   }
 
   async function onDelete(coupon) {
-    if (!confirm(`ลบคูปอง "${coupon.code}" ?`)) return;
+    const confirmed = await popup.confirm(`ลบคูปอง "${coupon.code}" ?`, {
+      title: "ยืนยันการลบคูปอง",
+      confirmText: "ลบคูปอง",
+      cancelText: "ยกเลิก",
+      tone: "error",
+    });
+    if (confirmed === false) return;
     const res = await fetch(`/api/coupons/${coupon._id}`, { method: "DELETE" });
     const data = await res.json();
     if (!res.ok) {
-      alert(data?.error || "Delete failed");
+      await popup.alert(data?.error || "ลบคูปองไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     await load();
@@ -171,7 +185,10 @@ export default function AdminCouponsPage() {
     });
     const data = await res.json();
     if (!res.ok) {
-      alert(data?.error || "Update failed");
+      await popup.alert(data?.error || "อัปเดตสถานะไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     setItems((prev) => prev.map((c) => (c._id === coupon._id ? { ...c, active: newValue } : c)));

--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -1,43 +1,46 @@
 import Link from "next/link";
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import { AdminPopupProvider } from "@/components/admin/AdminPopupProvider";
 
 export const metadata = { title: "Admin | Sweet Cravings" };
 
 export default function AdminLayout({ children }) {
   return (
-    <div className="relative min-h-screen bg-[radial-gradient(circle_at_15%_20%,#4f1818,transparent_55%),radial-gradient(circle_at_80%_0%,#2b0c0c,transparent_50%),radial-gradient(circle_at_100%_80%,#180404,transparent_45%)] text-[var(--color-gold)] lg:flex">
-      <AdminSidebar />
+    <AdminPopupProvider>
+      <div className="relative min-h-screen bg-[radial-gradient(circle_at_15%_20%,#4f1818,transparent_55%),radial-gradient(circle_at_80%_0%,#2b0c0c,transparent_50%),radial-gradient(circle_at_100%_80%,#180404,transparent_45%)] text-[var(--color-gold)] lg:flex">
+        <AdminSidebar />
 
-      <main className="flex-1 lg:ml-0">
-        <div className="sticky top-0 z-30 border-b border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/80 backdrop-blur-md">
-          <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between lg:px-10">
-            <div>
-              <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-gold)]/60">
-                Sweet Cravings Admin
-              </p>
-              <h1 className="mt-1 text-2xl font-semibold text-[var(--color-rose)]">
-                แผงควบคุมการจัดการร้าน
-              </h1>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)]"
-              >
-                🏬 กลับหน้าร้าน
-              </Link>
-              <Link
-                href="/orders"
-                className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/40 transition hover:bg-[var(--color-rose-dark)]"
-              >
-                🛒 ดูร้านแบบลูกค้า
-              </Link>
+        <main className="flex-1 lg:ml-0">
+          <div className="sticky top-0 z-30 border-b border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/80 backdrop-blur-md">
+            <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between lg:px-10">
+              <div>
+                <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-gold)]/60">
+                  Sweet Cravings Admin
+                </p>
+                <h1 className="mt-1 text-2xl font-semibold text-[var(--color-rose)]">
+                  แผงควบคุมการจัดการร้าน
+                </h1>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Link
+                  href="/"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/70 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)]"
+                >
+                  🏬 กลับหน้าร้าน
+                </Link>
+                <Link
+                  href="/orders"
+                  className="inline-flex items-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/40 transition hover:bg-[var(--color-rose-dark)]"
+                >
+                  🛒 ดูร้านแบบลูกค้า
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="px-5 pb-20 pt-8 lg:px-10">{children}</div>
-      </main>
-    </div>
+          <div className="px-5 pb-20 pt-8 lg:px-10">{children}</div>
+        </main>
+      </div>
+    </AdminPopupProvider>
   );
 }

--- a/app/admin/orders/page.jsx
+++ b/app/admin/orders/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
 
 const statusOptions = ["all", "new", "pending", "shipping", "success", "cancel"];
 
@@ -69,6 +70,7 @@ export default function AdminOrdersPage() {
   const [selectedSlip, setSelectedSlip] = useState(null);
   const [updating, setUpdating] = useState("");
   const [updatingPayment, setUpdatingPayment] = useState("");
+  const popup = useAdminPopup();
 
   async function load() {
     setLoading(true);
@@ -99,12 +101,18 @@ export default function AdminOrdersPage() {
       });
       const data = await res.json();
       if (!res.ok) {
-        alert(data?.error || "Update failed");
+        await popup.alert(data?.error || "อัปเดตสถานะไม่สำเร็จ", {
+          title: "เกิดข้อผิดพลาด",
+          tone: "error",
+        });
         return;
       }
       setOrders((prev) => prev.map((o) => (o._id === id ? data : o)));
     } catch (e) {
-      alert(e?.message || "Update failed");
+      await popup.alert(e?.message || "อัปเดตสถานะไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
     } finally {
       setUpdating("");
     }
@@ -123,12 +131,18 @@ export default function AdminOrdersPage() {
       });
       const data = await res.json();
       if (!res.ok) {
-        alert(data?.error || "Update payment failed");
+        await popup.alert(data?.error || "อัปเดตสถานะการชำระเงินไม่สำเร็จ", {
+          title: "เกิดข้อผิดพลาด",
+          tone: "error",
+        });
         return;
       }
       setOrders((prev) => prev.map((o) => (o._id === order._id ? data : o)));
     } catch (e) {
-      alert(e?.message || "Update payment failed");
+      await popup.alert(e?.message || "อัปเดตสถานะการชำระเงินไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
     } finally {
       setUpdatingPayment("");
     }

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import slugify from "slugify";
+import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
 
 const emptyProduct = {
   title: "",
@@ -52,6 +53,7 @@ export default function AdminProductsPage() {
   const [form, setForm] = useState(emptyProduct);
   const [search, setSearch] = useState("");
   const [saving, setSaving] = useState(false);
+  const popup = useAdminPopup();
 
   const isEdit = useMemo(() => Boolean(editing?._id), [editing]);
 
@@ -131,7 +133,10 @@ export default function AdminProductsPage() {
     const data = await res.json();
     setSaving(false);
     if (!res.ok) {
-      alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ");
+      await popup.alert(data?.error || "บันทึกข้อมูลไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     setEditing(null);
@@ -139,11 +144,20 @@ export default function AdminProductsPage() {
   }
 
   async function onDelete(p) {
-    if (!confirm(`ลบสินค้า "${p.title}" ?`)) return;
+    const confirmed = await popup.confirm(`ลบสินค้า "${p.title}" ?`, {
+      title: "ยืนยันการลบสินค้า",
+      confirmText: "ลบสินค้า",
+      cancelText: "ยกเลิก",
+      tone: "error",
+    });
+    if (!confirmed) return;
     const res = await fetch(`/api/products/${p._id}`, { method: "DELETE" });
     const data = await res.json();
     if (!res.ok) {
-      alert(data?.error || "Delete failed");
+      await popup.alert(data?.error || "ลบสินค้าไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     await load();
@@ -158,7 +172,10 @@ export default function AdminProductsPage() {
     });
     const data = await res.json();
     if (!res.ok) {
-      alert(data?.error || "Update failed");
+      await popup.alert(data?.error || "อัปเดตสถานะไม่สำเร็จ", {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
       return;
     }
     setItems((prev) => prev.map((x) => (x._id === p._id ? { ...x, active: newValue } : x)));
@@ -510,7 +527,10 @@ export default function AdminProductsPage() {
                           try {
                             await onUpload(file);
                           } catch (error) {
-                            alert(String(error.message || error));
+                            await popup.alert(String(error.message || error), {
+                              title: "อัปโหลดรูปไม่สำเร็จ",
+                              tone: "error",
+                            });
                           }
                         }}
                         className="w-full rounded-[1rem] border border-dashed border-[#D2691E]/40 bg-white/70 px-4 py-3 text-sm text-[#8B4513]/70 file:mr-4 file:rounded-full file:border-0 file:bg-[#D2691E]/10 file:px-4 file:py-2 file:text-[#D2691E]"

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
 
 const roleLabels = {
   admin: "ผู้ดูแลระบบ",
@@ -40,6 +41,7 @@ export default function AdminUsersPage() {
   const [err, setErr] = useState("");
   const [search, setSearch] = useState("");
   const [busy, setBusy] = useState({});
+  const popup = useAdminPopup();
 
   async function load() {
     setLoading(true);
@@ -71,7 +73,17 @@ export default function AdminUsersPage() {
 
   async function updateUser(id, payload, options = {}) {
     const { confirmMessage } = options;
-    if (confirmMessage && !confirm(confirmMessage)) return;
+    if (confirmMessage) {
+      const confirmed = await popup.confirm(confirmMessage, {
+        title: "ยืนยันการทำรายการ",
+        confirmText: "ยืนยัน",
+        cancelText: "ยกเลิก",
+        tone: "warning",
+      });
+      if (confirmed === false) {
+        return;
+      }
+    }
 
     setBusyFor(id, true);
     try {
@@ -89,7 +101,10 @@ export default function AdminUsersPage() {
         setUsers((prev) => prev.map((u) => (u.id === id ? data.user : u)));
       }
     } catch (e) {
-      alert(String(e.message || e));
+      await popup.alert(String(e.message || e), {
+        title: "เกิดข้อผิดพลาด",
+        tone: "error",
+      });
     } finally {
       setBusyFor(id, false);
     }

--- a/components/admin/AdminPopupProvider.jsx
+++ b/components/admin/AdminPopupProvider.jsx
@@ -1,0 +1,198 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+const PopupContext = createContext(null);
+
+export function useAdminPopup() {
+  const context = useContext(PopupContext);
+  if (!context) {
+    throw new Error("useAdminPopup must be used within an AdminPopupProvider");
+  }
+  return context;
+}
+
+const toneMap = {
+  info: {
+    icon: "ℹ️",
+    accent: "bg-sky-500",
+    accentHover: "hover:bg-sky-600",
+    accentRing: "focus-visible:ring-sky-300",
+    badge: "bg-sky-500/10 text-sky-100 border border-sky-500/20",
+    cancel: "border border-sky-500/30 text-sky-100 hover:bg-sky-500/10",
+  },
+  success: {
+    icon: "✨",
+    accent: "bg-emerald-500",
+    accentHover: "hover:bg-emerald-600",
+    accentRing: "focus-visible:ring-emerald-300",
+    badge: "bg-emerald-500/10 text-emerald-100 border border-emerald-500/20",
+    cancel: "border border-emerald-500/30 text-emerald-100 hover:bg-emerald-500/10",
+  },
+  warning: {
+    icon: "⚠️",
+    accent: "bg-amber-500",
+    accentHover: "hover:bg-amber-600",
+    accentRing: "focus-visible:ring-amber-300",
+    badge: "bg-amber-500/10 text-amber-100 border border-amber-500/20",
+    cancel: "border border-amber-500/30 text-amber-100 hover:bg-amber-500/10",
+  },
+  error: {
+    icon: "✖️",
+    accent: "bg-rose-500",
+    accentHover: "hover:bg-rose-600",
+    accentRing: "focus-visible:ring-rose-300",
+    badge: "bg-rose-500/10 text-rose-100 border border-rose-500/20",
+    cancel: "border border-rose-500/30 text-rose-100 hover:bg-rose-500/10",
+  },
+};
+
+function getToneConfig(tone) {
+  return toneMap[tone] || toneMap.info;
+}
+
+export function AdminPopupProvider({ children }) {
+  const [popup, setPopup] = useState(null);
+
+  const close = useCallback(() => {
+    setPopup(null);
+  }, []);
+
+  const alert = useCallback((message, options = {}) => {
+    const { title = "แจ้งเตือน", tone = "info", confirmText = "ตกลง" } = options;
+    return new Promise((resolve) => {
+      setPopup({
+        variant: "alert",
+        title,
+        message,
+        tone,
+        confirmText,
+        resolve: (value) => {
+          resolve(value);
+          close();
+        },
+      });
+    });
+  }, [close]);
+
+  const confirm = useCallback((message, options = {}) => {
+    const {
+      title = "ยืนยันการทำรายการ",
+      tone = "warning",
+      confirmText = "ยืนยัน",
+      cancelText = "ยกเลิก",
+    } = options;
+    return new Promise((resolve) => {
+      setPopup({
+        variant: "confirm",
+        title,
+        message,
+        tone,
+        confirmText,
+        cancelText,
+        resolve: (value) => {
+          resolve(value);
+          close();
+        },
+      });
+    });
+  }, [close]);
+
+  useEffect(() => {
+    if (!popup) return undefined;
+
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        popup.resolve(popup.variant === "confirm" ? false : true);
+      }
+    };
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [popup]);
+
+  const value = useMemo(
+    () => ({
+      alert,
+      confirm,
+    }),
+    [alert, confirm]
+  );
+
+  return (
+    <PopupContext.Provider value={value}>
+      {children}
+      {popup ? <PopupOverlay popup={popup} /> : null}
+    </PopupContext.Provider>
+  );
+}
+
+function PopupOverlay({ popup }) {
+  const tone = getToneConfig(popup.tone);
+
+  const handleConfirm = () => {
+    popup.resolve(true);
+  };
+
+  const handleCancel = () => {
+    popup.resolve(false);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+      onClick={() => popup.resolve(popup.variant === "confirm" ? false : true)}
+    >
+      <div
+        className="relative w-full max-w-md overflow-hidden rounded-3xl border border-white/20 bg-[var(--color-burgundy-dark,#1d0505)]/95 text-white shadow-2xl shadow-black/40"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className={`absolute inset-x-0 top-0 h-1 ${tone.accent}`} />
+        <div className="space-y-6 px-7 py-8">
+          <div className="flex items-start gap-4">
+            <div className={`flex h-12 w-12 items-center justify-center rounded-2xl text-2xl ${tone.badge}`}>
+              {tone.icon}
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-white">{popup.title}</h3>
+              <p className="text-sm leading-relaxed text-white/80">{popup.message}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            {popup.variant === "confirm" ? (
+              <button
+                type="button"
+                onClick={handleCancel}
+                className={`inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-burgundy-dark,#1d0505)] ${tone.cancel}`}
+              >
+                {popup.cancelText}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleConfirm}
+              className={`inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-black/30 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-burgundy-dark,#1d0505)] ${tone.accent} ${tone.accentHover} ${tone.accentRing}`}
+            >
+              {popup.confirmText}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an AdminPopupProvider with reusable alert and confirm helpers styled for the admin area
- wrap the admin layout with the popup provider and update product, coupon, order, and user screens to use the new UI dialogs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f3311ae0832da597c8c09891e605