### PR TITLE
Fix NextAuth token check for secure cookies

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -3,7 +3,9 @@ import { getToken } from "next-auth/jwt";
 
 export async function middleware(req) {
   const path = req.nextUrl.pathname;
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const secret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
+  const secureCookie = req.nextUrl.protocol === "https:";
+  const token = await getToken({ req, secret, secureCookie });
 
   // ต้องล็อกอิน: /orders/*
   if (path.startsWith("/orders")) {


### PR DESCRIPTION
## Summary
- ensure the middleware checks secure NextAuth cookies when requests come from HTTPS
- fall back to AUTH_SECRET when decoding the session token so deployments with the new env name work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5018846b4832dac47283647c0e893