### PR TITLE
Add customer review system

### DIFF
--- a/app/admin/reviews/page.jsx
+++ b/app/admin/reviews/page.jsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
+
+function extractApiError(error) {
+  if (!error) return "เกิดข้อผิดพลาด";
+  if (typeof error === "string") return error;
+  if (Array.isArray(error)) return error[0] || "เกิดข้อผิดพลาด";
+  if (error?.message) return error.message;
+  const fieldErrors = error?.fieldErrors || {};
+  for (const key of Object.keys(fieldErrors)) {
+    const list = fieldErrors[key];
+    if (Array.isArray(list) && list.length > 0) {
+      return list[0];
+    }
+  }
+  const formErrors = error?.formErrors;
+  if (Array.isArray(formErrors) && formErrors.length > 0) {
+    return formErrors[0];
+  }
+  return "เกิดข้อผิดพลาด";
+}
+
+function RatingPill({ rating }) {
+  const value = Number(rating || 0);
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-200">
+      <span>⭐</span>
+      {value.toFixed(1)}
+    </span>
+  );
+}
+
+function PublishedBadge({ published }) {
+  return published ? (
+    <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+      <span>🟢</span>
+      แสดงบนหน้าเว็บ
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-200">
+      <span>⚪️</span>
+      ซ่อนอยู่
+    </span>
+  );
+}
+
+export default function AdminReviewsPage() {
+  const popup = useAdminPopup();
+  const [reviews, setReviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [updatingId, setUpdatingId] = useState("");
+  const [removingId, setRemovingId] = useState("");
+
+  const loadReviews = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/admin/reviews", { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data?.error || "โหลดรีวิวไม่สำเร็จ");
+      }
+      setReviews(Array.isArray(data?.reviews) ? data.reviews : []);
+    } catch (err) {
+      setError(String(err.message || err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadReviews();
+  }, [loadReviews]);
+
+  const totalPublished = useMemo(
+    () => reviews.filter((review) => review.published).length,
+    [reviews]
+  );
+
+  const featuredCount = useMemo(
+    () => reviews.filter((review) => review.published && Number(review.rating || 0) >= 3.5).length,
+    [reviews]
+  );
+
+  const averageRating = useMemo(() => {
+    if (reviews.length === 0) return 0;
+    const sum = reviews.reduce((total, review) => total + Number(review.rating || 0), 0);
+    return sum / reviews.length;
+  }, [reviews]);
+
+  const handleTogglePublished = useCallback(
+    async (review) => {
+      if (!review?.id) return;
+      setUpdatingId(review.id);
+      try {
+        const res = await fetch(`/api/admin/reviews/${review.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ published: !review.published }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(extractApiError(data?.error));
+        }
+        setReviews((prev) => prev.map((item) => (item.id === review.id ? data.review : item)));
+      } catch (err) {
+        await popup.alert(err.message || "อัปเดตสถานะไม่สำเร็จ", {
+          tone: "error",
+          title: "ไม่สามารถอัปเดตรีวิวได้",
+        });
+      } finally {
+        setUpdatingId("");
+      }
+    },
+    [popup]
+  );
+
+  const handleDelete = useCallback(
+    async (review) => {
+      if (!review?.id) return;
+      const confirmed = await popup.confirm(
+        `ต้องการลบรีวิวของ ${review.userName || "ลูกค้า"} หรือไม่?`,
+        {
+          tone: "warning",
+          title: "ลบรีวิว",
+          confirmText: "ลบรีวิว",
+        }
+      );
+      if (!confirmed) return;
+
+      setRemovingId(review.id);
+      try {
+        const res = await fetch(`/api/admin/reviews/${review.id}`, {
+          method: "DELETE",
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(extractApiError(data?.error));
+        }
+        setReviews((prev) => prev.filter((item) => item.id !== review.id));
+        await popup.alert("ลบรีวิวเรียบร้อยแล้ว", {
+          tone: "success",
+          title: "ดำเนินการสำเร็จ",
+        });
+      } catch (err) {
+        await popup.alert(err.message || "ลบรีวิวไม่สำเร็จ", {
+          tone: "error",
+          title: "เกิดข้อผิดพลาด",
+        });
+      } finally {
+        setRemovingId("");
+      }
+    },
+    [popup]
+  );
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-[2rem] border border-white/10 bg-[var(--color-burgundy)]/70 p-6 shadow-xl shadow-black/30 backdrop-blur">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-[var(--color-rose)]">รีวิวจากลูกค้า</h2>
+            <p className="mt-1 text-sm text-[var(--color-gold)]/70">
+              ตรวจสอบเสียงตอบรับและจัดการการแสดงผลรีวิวบนหน้าเว็บไซต์
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <div className="rounded-2xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy-dark)]/70 px-4 py-3 text-sm text-[var(--color-gold)]/80">
+              รวมทั้งหมด {reviews.length} รีวิว
+            </div>
+            <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm font-semibold text-emerald-100">
+              เผยแพร่ {totalPublished} รีวิว
+            </div>
+            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm font-semibold text-amber-100">
+              รีวิวเด่น {featuredCount}
+            </div>
+            <div className="rounded-2xl border border-[var(--color-rose)]/30 bg-[var(--color-rose)]/10 px-4 py-3 text-sm font-semibold text-[var(--color-rose)]/90">
+              ค่าเฉลี่ย {averageRating.toFixed(2)} ⭐
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-white/10 bg-[var(--color-burgundy)]/70 p-6 shadow-xl shadow-black/30 backdrop-blur">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-xl font-semibold text-[var(--color-rose)]">รายการรีวิวทั้งหมด</h3>
+            <p className="text-sm text-[var(--color-gold)]/70">
+              คลิกเพื่อซ่อน/แสดงบนหน้าเว็บหรือจัดการรีวิวที่ไม่เหมาะสม
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={loadReviews}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/70 px-4 py-2 text-sm font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            🔄 รีเฟรช
+          </button>
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="mt-8 flex items-center gap-3 rounded-2xl border border-white/20 bg-white/5 px-6 py-5 text-sm text-[var(--color-gold)]/80">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--color-rose)] border-t-transparent" />
+            กำลังโหลดข้อมูลรีวิว...
+          </div>
+        ) : reviews.length === 0 ? (
+          <div className="mt-8 rounded-2xl border border-white/20 bg-white/5 px-6 py-8 text-center text-sm text-[var(--color-gold)]/70">
+            ยังไม่มีรีวิวจากลูกค้า
+          </div>
+        ) : (
+          <div className="mt-6 overflow-hidden rounded-[1.5rem] border border-white/20 bg-white/5">
+            <table className="w-full text-sm text-[var(--color-gold)]/80">
+              <thead className="bg-white/5 text-[var(--color-rose)]">
+                <tr>
+                  <th className="px-5 py-4 text-left">ลูกค้า</th>
+                  <th className="px-5 py-4 text-left">คอมเมนต์</th>
+                  <th className="px-5 py-4 text-left">ให้คะแนน</th>
+                  <th className="px-5 py-4 text-left">สถานะ</th>
+                  <th className="px-5 py-4 text-left">อัปเดตล่าสุด</th>
+                  <th className="px-5 py-4 text-right">จัดการ</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {reviews.map((review) => (
+                  <tr key={review.id} className="hover:bg-white/5">
+                    <td className="px-5 py-4 align-top text-[var(--color-gold)]">
+                      <div className="font-semibold text-[var(--color-rose)]">
+                        {review.userName || "ลูกค้า"}
+                      </div>
+                      {review.userEmail && (
+                        <div className="text-xs text-[var(--color-gold)]/60">{review.userEmail}</div>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <p className="max-w-md text-sm leading-relaxed text-[var(--color-gold)]/80 line-clamp-4">
+                        {review.comment || "-"}
+                      </p>
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <RatingPill rating={review.rating} />
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <PublishedBadge published={review.published} />
+                    </td>
+                    <td className="px-5 py-4 align-top text-xs text-[var(--color-gold)]/60">
+                      {review.updatedAt
+                        ? new Date(review.updatedAt).toLocaleString("th-TH", {
+                            dateStyle: "medium",
+                            timeStyle: "short",
+                          })
+                        : "-"}
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleTogglePublished(review)}
+                          disabled={updatingId === review.id || removingId === review.id}
+                          className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)]/70 px-4 py-2 text-xs font-semibold text-[var(--color-rose)] transition hover:bg-[var(--color-burgundy)] disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {review.published ? "ซ่อนรีวิว" : "แสดงบนหน้าเว็บ"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(review)}
+                          disabled={removingId === review.id || updatingId === review.id}
+                          className="inline-flex items-center gap-2 rounded-full border border-rose-400/40 bg-rose-500/10 px-4 py-2 text-xs font-semibold text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {removingId === review.id ? "กำลังลบ..." : "ลบ"}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/api/admin/reviews/[id]/route.js
+++ b/app/api/admin/reviews/[id]/route.js
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { Types } from "mongoose";
+import { z } from "zod";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { Review } from "@/models/Review";
+
+function serializeAdminReview(review) {
+  const user = review.user || {};
+  return {
+    id: String(review._id),
+    userName: review.userName || user.name || "ลูกค้า",
+    userEmail: user.email || "",
+    rating: Number(review.rating || 0),
+    comment: review.comment || "",
+    published: !!review.published,
+    createdAt: review.createdAt ? new Date(review.createdAt).toISOString() : null,
+    updatedAt: review.updatedAt ? new Date(review.updatedAt).toISOString() : null,
+  };
+}
+
+const updateSchema = z
+  .object({
+    published: z.boolean().optional(),
+    userName: z
+      .string()
+      .trim()
+      .min(1, "กรุณาระบุชื่อผู้รีวิว")
+      .max(120, "ชื่อยาวเกินไป")
+      .optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "ไม่มีข้อมูลที่ต้องการแก้ไข",
+    path: ["published"],
+  });
+
+export async function PATCH(req, { params }) {
+  const { id } = await params;
+
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Invalid review id" }, { status: 400 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const updates = {};
+  if (Object.prototype.hasOwnProperty.call(parsed.data, "published")) {
+    updates.published = parsed.data.published;
+  }
+  if (parsed.data.userName) {
+    updates.userName = parsed.data.userName.trim();
+  }
+
+  await connectToDatabase();
+  const updated = await Review.findByIdAndUpdate(id, updates, { new: true })
+    .populate({ path: "user", select: "email name" })
+    .lean();
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ review: serializeAdminReview(updated) });
+}
+
+export async function DELETE(req, { params }) {
+  const { id } = await params;
+
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Invalid review id" }, { status: 400 });
+  }
+
+  await connectToDatabase();
+  const deleted = await Review.findByIdAndDelete(id).lean();
+  if (!deleted) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/admin/reviews/route.js
+++ b/app/api/admin/reviews/route.js
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { Review } from "@/models/Review";
+
+function serializeAdminReview(review) {
+  const user = review.user || {};
+  return {
+    id: String(review._id),
+    userName: review.userName || user.name || "ลูกค้า",
+    userEmail: user.email || "",
+    rating: Number(review.rating || 0),
+    comment: review.comment || "",
+    published: !!review.published,
+    createdAt: review.createdAt ? new Date(review.createdAt).toISOString() : null,
+    updatedAt: review.updatedAt ? new Date(review.updatedAt).toISOString() : null,
+  };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await connectToDatabase();
+  const docs = await Review.find({})
+    .sort({ createdAt: -1 })
+    .populate({ path: "user", select: "email name" })
+    .lean();
+
+  return NextResponse.json({ reviews: docs.map(serializeAdminReview) });
+}

--- a/app/api/reviews/me/route.js
+++ b/app/api/reviews/me/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { Review } from "@/models/Review";
+
+function serialize(review) {
+  return {
+    id: String(review._id),
+    rating: Number(review.rating || 0),
+    comment: review.comment || "",
+    published: !!review.published,
+    createdAt: review.createdAt ? new Date(review.createdAt).toISOString() : null,
+    updatedAt: review.updatedAt ? new Date(review.updatedAt).toISOString() : null,
+  };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await connectToDatabase();
+  const review = await Review.findOne({ user: session.user.id }).lean();
+  if (!review) {
+    return NextResponse.json({ review: null });
+  }
+
+  return NextResponse.json({ review: serialize(review) });
+}

--- a/app/api/reviews/route.js
+++ b/app/api/reviews/route.js
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+
+import { authOptions } from "@/lib/auth";
+import { connectToDatabase } from "@/lib/db";
+import { Review } from "@/models/Review";
+
+const createSchema = z.object({
+  rating: z.coerce.number().min(1).max(5),
+  comment: z
+    .string()
+    .trim()
+    .min(5, "กรุณาเขียนรีวิวอย่างน้อย 5 ตัวอักษร")
+    .max(600, "รีวิวยาวเกินไป"),
+});
+
+function normalizeRating(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) return 1;
+  const clamped = Math.min(5, Math.max(1, value));
+  return Math.round(clamped * 2) / 2;
+}
+
+function serializePublicReview(review) {
+  return {
+    id: String(review._id),
+    name: review.userName || "ลูกค้า",
+    rating: Number(review.rating || 0),
+    comment: review.comment || "",
+    createdAt: review.createdAt ? new Date(review.createdAt).toISOString() : null,
+  };
+}
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url);
+  const featured = searchParams.get("featured");
+  const minRatingParam = searchParams.get("minRating");
+  const limitParam = searchParams.get("limit");
+
+  let minRating = 0;
+  if (featured === "true") {
+    minRating = 3.5;
+  }
+  if (minRatingParam != null) {
+    const parsed = Number(minRatingParam);
+    if (!Number.isNaN(parsed)) {
+      minRating = Math.max(minRating, parsed);
+    }
+  }
+
+  const limit = Math.min(100, Math.max(1, Number.parseInt(limitParam || "0", 10) || (featured === "true" ? 50 : 20)));
+
+  const filter = { published: true };
+  if (minRating > 0) {
+    filter.rating = { $gte: minRating };
+  }
+
+  await connectToDatabase();
+  const query = Review.find(filter).sort({ createdAt: -1 }).limit(limit);
+  const docs = await query.lean();
+
+  return NextResponse.json({
+    reviews: docs.map(serializePublicReview),
+  });
+}
+
+export async function POST(req) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "ต้องเข้าสู่ระบบก่อนจึงจะรีวิวได้" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const rating = normalizeRating(parsed.data.rating);
+  const comment = parsed.data.comment.trim();
+
+  await connectToDatabase();
+
+  const payload = {
+    rating,
+    comment,
+    userName: session.user?.name || session.user?.email || "ลูกค้า",
+    published: true,
+  };
+
+  const review = await Review.findOneAndUpdate(
+    { user: session.user.id },
+    { ...payload, user: session.user.id },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  ).lean();
+
+  return NextResponse.json({
+    review: serializePublicReview(review),
+  });
+}

--- a/components/ReviewsShowcase.jsx
+++ b/components/ReviewsShowcase.jsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+
+function StarRating({ value }) {
+  const stars = useMemo(() => {
+    return Array.from({ length: 5 }).map((_, index) => {
+      const fill = Math.max(0, Math.min(1, value - index));
+      return (
+        <span key={index} className="relative inline-block h-5 w-5 text-lg leading-none text-[var(--color-rose)]">
+          <span className="absolute inset-0 text-[var(--color-rose)]/20">★</span>
+          <span
+            className="absolute inset-0 overflow-hidden text-[var(--color-rose)]"
+            style={{ width: `${fill * 100}%` }}
+          >
+            ★
+          </span>
+          <span className="sr-only">{Math.round(fill * 100)}%</span>
+        </span>
+      );
+    });
+  }, [value]);
+
+  return (
+    <div className="flex items-center gap-1">
+      {stars}
+      <span className="ml-2 text-sm font-semibold text-[var(--color-gold)]/80">{value.toFixed(1)}</span>
+    </div>
+  );
+}
+
+function extractErrorMessage(error) {
+  if (!error) return "ส่งรีวิวไม่สำเร็จ";
+  if (typeof error === "string") return error;
+  if (Array.isArray(error)) {
+    return error[0] || "ส่งรีวิวไม่สำเร็จ";
+  }
+  const { formErrors, fieldErrors } = error;
+  if (Array.isArray(formErrors) && formErrors.length > 0) {
+    return formErrors[0];
+  }
+  if (fieldErrors) {
+    for (const key of Object.keys(fieldErrors)) {
+      const list = fieldErrors[key];
+      if (Array.isArray(list) && list.length > 0) {
+        return list[0];
+      }
+    }
+  }
+  return "ส่งรีวิวไม่สำเร็จ";
+}
+
+export default function ReviewsShowcase({ reviews: initialReviews = [] }) {
+  const { data: session, status } = useSession();
+  const [reviews, setReviews] = useState(initialReviews);
+  const [currentStart, setCurrentStart] = useState(0);
+  const [myReview, setMyReview] = useState(null);
+  const [formRating, setFormRating] = useState(5);
+  const [formComment, setFormComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState(null);
+
+  const loadFeatured = useCallback(async () => {
+    try {
+      const res = await fetch("/api/reviews?featured=true", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data?.reviews)) {
+        setReviews(data.reviews);
+      }
+    } catch (error) {
+      console.error("โหลดรีวิวไม่สำเร็จ", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    setReviews(initialReviews);
+  }, [initialReviews]);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      if (status !== "authenticated") {
+        setMyReview(null);
+        return;
+      }
+      try {
+        const res = await fetch("/api/reviews/me", { cache: "no-store" });
+        const data = await res.json();
+        if (!active) return;
+        if (!res.ok) {
+          throw new Error(data?.error || "โหลดรีวิวของฉันไม่สำเร็จ");
+        }
+        if (data?.review) {
+          setMyReview(data.review);
+          setFormRating(data.review.rating || 5);
+          setFormComment(data.review.comment || "");
+        } else {
+          setMyReview(null);
+          setFormRating(5);
+          setFormComment("");
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [status]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      await loadFeatured();
+      if (cancelled) return;
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadFeatured]);
+
+  useEffect(() => {
+    setCurrentStart(0);
+  }, [reviews.length]);
+
+  useEffect(() => {
+    if (reviews.length <= 3) return undefined;
+    const interval = setInterval(() => {
+      setCurrentStart((prev) => {
+        const next = (prev + 3) % reviews.length;
+        return next;
+      });
+    }, 8000);
+    return () => clearInterval(interval);
+  }, [reviews]);
+
+  const visibleReviews = useMemo(() => {
+    if (!Array.isArray(reviews) || reviews.length === 0) return [];
+    if (reviews.length <= 3) return reviews;
+    const list = [];
+    for (let i = 0; i < Math.min(3, reviews.length); i += 1) {
+      const index = (currentStart + i) % reviews.length;
+      list.push(reviews[index]);
+    }
+    return list;
+  }, [reviews, currentStart]);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (status !== "authenticated") {
+        setMessage({ type: "error", text: "กรุณาเข้าสู่ระบบก่อนรีวิว" });
+        return;
+      }
+      if (formComment.trim().length < 5) {
+        setMessage({ type: "error", text: "กรุณาเขียนรีวิวอย่างน้อย 5 ตัวอักษร" });
+        return;
+      }
+
+      setSubmitting(true);
+      setMessage(null);
+      try {
+        const res = await fetch("/api/reviews", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ rating: formRating, comment: formComment }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(extractErrorMessage(data?.error));
+        }
+        setMessage({ type: "success", text: "ขอบคุณสำหรับรีวิว!" });
+        setMyReview(data.review);
+        setFormRating(Number(data.review?.rating ?? formRating));
+        setFormComment(data.review?.comment ?? "");
+        await loadFeatured();
+      } catch (error) {
+        setMessage({ type: "error", text: String(error.message || error) });
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [status, formRating, formComment, loadFeatured]
+  );
+
+  const avgRating = useMemo(() => {
+    if (!Array.isArray(reviews) || reviews.length === 0) return 0;
+    const sum = reviews.reduce((acc, item) => acc + Number(item.rating || 0), 0);
+    return sum / reviews.length;
+  }, [reviews]);
+
+  return (
+    <section className="relative overflow-hidden py-16">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_0%_0%,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_90%_10%,rgba(58,16,16,0.7),transparent_60%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(76,25,18,0.85))]" />
+      <div className="relative mx-auto max-w-screen-xl px-6 lg:px-8">
+        <div className="rounded-[2.5rem] border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
+          <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[1.4fr_0.9fr] lg:items-start">
+            <div className="space-y-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--color-rose)]/90">
+                    Our Happy Customers
+                  </p>
+                  <h2 className="mt-1 text-3xl font-bold text-[var(--color-rose)]">เสียงตอบรับจากลูกค้า</h2>
+                </div>
+                <div className="inline-flex items-center gap-3 rounded-full border border-[var(--color-rose)]/20 bg-[var(--color-burgundy-dark)]/70 px-4 py-2 shadow-inner">
+                  <StarRating value={reviews.length > 0 ? Math.max(3.5, Math.min(5, avgRating)) : 5} />
+                  <span className="text-xs text-[var(--color-gold)]/80">จากลูกค้าที่รักในรสชาติ</span>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {visibleReviews.length === 0 && (
+                  <div className="md:col-span-2 xl:col-span-3 rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy-dark)]/60 p-8 text-center text-[var(--color-gold)]/70 shadow-lg">
+                    ยังไม่มีรีวิวตอนนี้ มาร่วมเป็นคนแรกที่รีวิวความอร่อยกันนะคะ!
+                  </div>
+                )}
+                {visibleReviews.map((review) => (
+                  <article
+                    key={review.id}
+                    className="flex h-full flex-col gap-4 rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy-dark)]/60 p-6 shadow-lg shadow-black/30"
+                  >
+                    <StarRating value={Number(review.rating || 0)} />
+                    <p className="flex-1 text-sm leading-relaxed text-[var(--color-gold)]/90">“{review.comment}”</p>
+                    <div className="flex items-center justify-between text-sm text-[var(--color-rose)]/80">
+                      <span className="font-semibold">{review.name}</span>
+                      {review.createdAt && (
+                        <time dateTime={review.createdAt} className="text-xs text-[var(--color-gold)]/60">
+                          {new Date(review.createdAt).toLocaleDateString("th-TH", {
+                            year: "numeric",
+                            month: "short",
+                          })}
+                        </time>
+                      )}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-[var(--color-rose)]/20 bg-[var(--color-burgundy-dark)]/60 p-6 shadow-inner shadow-black/30">
+              <h3 className="text-xl font-semibold text-[var(--color-rose)]">
+                แชร์ประสบการณ์ของคุณ
+              </h3>
+              <p className="mt-2 text-sm text-[var(--color-gold)]/75">
+                รีวิวของคุณช่วยให้เราพัฒนาสูตรให้ดียิ่งขึ้น และเป็นกำลังใจให้ทีมครัวทุกวัน
+              </p>
+
+              {status === "loading" && (
+                <p className="mt-4 text-xs text-[var(--color-gold)]/70">กำลังตรวจสอบสถานะการเข้าสู่ระบบ...</p>
+              )}
+
+              {status === "unauthenticated" && (
+                <div className="mt-6 space-y-4 rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/60 p-5 text-sm text-[var(--color-gold)]/80">
+                  <p>ต้องเข้าสู่ระบบก่อนจึงจะสามารถให้คะแนนได้</p>
+                  <Link
+                    href="/login?redirect=/"
+                    className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/30 transition hover:bg-[var(--color-rose-dark)]"
+                  >
+                    เข้าสู่ระบบเพื่อรีวิว
+                  </Link>
+                </div>
+              )}
+
+              {status === "authenticated" && (
+                <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+                  <div className="space-y-2">
+                    <label className="text-sm font-semibold text-[var(--color-gold)]/90">
+                      ให้คะแนน (1 - 5 ดาว)
+                    </label>
+                    <div className="rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/60 p-4 shadow-inner">
+                      <div className="flex items-center justify-between gap-3">
+                        <StarRating value={Number(formRating)} />
+                        <span className="text-xs text-[var(--color-gold)]/70">{Number(formRating).toFixed(1)} ดาว</span>
+                      </div>
+                      <input
+                        type="range"
+                        min="1"
+                        max="5"
+                        step="0.5"
+                        value={formRating}
+                        onChange={(event) => setFormRating(Number(event.target.value))}
+                        className="mt-3 w-full accent-[var(--color-rose)]"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label htmlFor="review-comment" className="text-sm font-semibold text-[var(--color-gold)]/90">
+                      รีวิวของคุณ
+                    </label>
+                    <textarea
+                      id="review-comment"
+                      value={formComment}
+                      onChange={(event) => setFormComment(event.target.value)}
+                      minLength={5}
+                      maxLength={600}
+                      rows={5}
+                      className="w-full rounded-2xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/60 p-4 text-sm text-[var(--color-gold)]/90 shadow-inner outline-none focus:ring-2 focus:ring-[var(--color-rose)]/40"
+                      placeholder="บอกเล่าความประทับใจของคุณ เช่น รสชาติ ความสดใหม่ หรือการบริการ"
+                    />
+                    <p className="text-right text-xs text-[var(--color-gold)]/60">
+                      {formComment.length}/600 ตัวอักษร
+                    </p>
+                  </div>
+
+                  {message && (
+                    <div
+                      className={`rounded-2xl border px-4 py-3 text-sm ${
+                        message.type === "success"
+                          ? "border-emerald-200/40 bg-emerald-50/20 text-emerald-200"
+                          : "border-rose-200/40 bg-rose-50/10 text-rose-200"
+                      }`}
+                    >
+                      {message.text}
+                    </div>
+                  )}
+
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="w-full rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/40 transition hover:bg-[var(--color-rose-dark)] disabled:cursor-not-allowed disabled:bg-[var(--color-rose)]/60"
+                  >
+                    {submitting ? "กำลังบันทึกรีวิว..." : myReview ? "อัปเดตรีวิว" : "ส่งรีวิว"}
+                  </button>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -7,6 +7,7 @@ const items = [
   { href: "/admin", label: "แดชบอร์ด", icon: "📊" },
   { href: "/admin/products", label: "จัดการสินค้า", icon: "🧁" },
   { href: "/admin/orders", label: "คำสั่งซื้อ", icon: "🧾" },
+  { href: "/admin/reviews", label: "รีวิวลูกค้า", icon: "⭐" },
   { href: "/admin/users", label: "ผู้ใช้งาน", icon: "👥" },
   { href: "/admin/coupons", label: "คูปอง", icon: "🎟️" },
 ];

--- a/middleware.js
+++ b/middleware.js
@@ -3,7 +3,9 @@ import { getToken } from "next-auth/jwt";
 
 export async function middleware(req) {
   const path = req.nextUrl.pathname;
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const secret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
+  const secureCookie = req.nextUrl.protocol === "https:";
+  const token = await getToken({ req, secret, secureCookie });
 
   // ต้องล็อกอิน: /orders/*
   if (path.startsWith("/orders")) {

--- a/models/Review.js
+++ b/models/Review.js
@@ -1,0 +1,17 @@
+import { Schema, model, models } from "mongoose";
+
+const ReviewSchema = new Schema(
+  {
+    user: { type: Schema.Types.ObjectId, ref: "User", required: true, unique: true },
+    userName: { type: String, default: "" },
+    rating: { type: Number, required: true, min: 1, max: 5 },
+    comment: { type: String, default: "" },
+    published: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+ReviewSchema.index({ rating: -1 });
+ReviewSchema.index({ createdAt: -1 });
+
+export const Review = models.Review || model("Review", ReviewSchema);


### PR DESCRIPTION
## Summary
- add a Review model plus public and authenticated API routes so logged-in shoppers can submit ratings while the storefront fetches featured feedback
- embed a rotating review showcase on the home page with a star form that requires login and reuses the latest submission
- add an admin review management page with controls to publish or remove entries alongside supporting admin API endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5018846b4832dac47283647c0e893