### PR TITLE
Refresh pastry-inspired color palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,18 +4,18 @@
 @tailwind utilities;
 
 :root {
-  --color-cream: #a2805d;
-  --color-cream-soft: #8f694b;
-  --color-rose: #e5bd77;
-  --color-rose-dark: #d1a15f;
-  --color-gold: #f4dab0;
-  --color-text: #e5bd77;
-  --color-choco: #f9e8c7;
-  --color-burgundy: #7a573f;
-  --color-burgundy-soft: #6a4b37;
-  --color-burgundy-dark: #523a29;
-  --surface-strong: rgba(82, 58, 41, 0.82);
-  --surface-soft: rgba(106, 75, 55, 0.66);
+  --color-cream: #fff5e8;
+  --color-cream-soft: #ffe4c5;
+  --color-rose: #f5a97f;
+  --color-rose-dark: #e0794f;
+  --color-gold: #8c5a2b;
+  --color-text: #4f2b16;
+  --color-choco: #f8dec5;
+  --color-burgundy: #e8b899;
+  --color-burgundy-soft: #dda178;
+  --color-burgundy-dark: #b8744f;
+  --surface-strong: rgba(255, 241, 220, 0.92);
+  --surface-soft: rgba(255, 232, 208, 0.82);
   --layout-max: 1200px;
 }
 
@@ -28,7 +28,7 @@ body {
   margin: 0;
   background: radial-gradient(
     circle at top,
-    #b18f6c 0%,
+    #fff2e3 0%,
     var(--color-cream) 55%,
     var(--color-burgundy-dark) 100%
   );
@@ -45,46 +45,46 @@ a:hover {
 } */
 
 ::selection {
-  background: rgba(240, 200, 105, 0.35);
+  background: rgba(245, 169, 127, 0.35);
 }
 
 label {
-  color: rgba(229, 189, 119, 0.9);
+  color: rgba(140, 90, 43, 0.8);
 }
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   * {
-    border-color: rgba(229, 189, 119, 0.25);
+    border-color: rgba(140, 90, 43, 0.18);
   }
 
   input,
   textarea,
   select {
-    background-color: rgba(122, 87, 63, 0.55);
+    background-color: rgba(248, 222, 197, 0.6);
     color: var(--color-text);
   }
 
   input::placeholder,
   textarea::placeholder {
-    color: rgba(229, 189, 119, 0.65);
+    color: rgba(140, 90, 43, 0.5);
   }
 }
 
 :is(.bg-white, .bg-white\/95, .bg-white\/90, .bg-white\/85) {
   background-color: var(--surface-strong) !important;
   color: var(--color-text) !important;
-  border-color: rgba(229, 189, 119, 0.24) !important;
-  box-shadow: 0 22px 46px -32px rgba(25, 16, 9, 0.72);
+  border-color: rgba(140, 90, 43, 0.22) !important;
+  box-shadow: 0 18px 44px -26px rgba(79, 43, 22, 0.35);
   backdrop-filter: blur(14px);
 }
 
 :is(.bg-white\/80, .bg-white\/70, .bg-white\/60) {
   background-color: var(--surface-soft) !important;
   color: var(--color-text) !important;
-  border-color: rgba(229, 189, 119, 0.18) !important;
+  border-color: rgba(140, 90, 43, 0.16) !important;
   backdrop-filter: blur(12px);
 }


### PR DESCRIPTION
## Summary
- switch global color tokens to a soft cream-and-caramel palette that better matches a steamed bun shop brand
- adjust base styles, selections, form fields, and glassmorphism surfaces to align with the new light theme across user and admin areas

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68da2b421d20832db1c89f7855c7da6b