### PR TITLE
Remove gradient backgrounds across pages

### DIFF
--- a/app/(site)/about/page.jsx
+++ b/app/(site)/about/page.jsx
@@ -56,7 +56,7 @@ export default function AboutPage() {
   return (
     <div className="relative overflow-hidden">
       <div
-        className="absolute inset-0 bg-gradient-to-b from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.92)] to-[var(--color-burgundy)]"
+        className="absolute inset-0 bg-[var(--color-burgundy-dark)]"
         aria-hidden
       />
 
@@ -94,7 +94,7 @@ export default function AboutPage() {
           </div>
 
           <div className="relative flex justify-center">
-            <div className="relative w-full max-w-sm rounded-[48%] border border-[var(--color-rose)]/30 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.85)] to-[var(--color-burgundy)] p-10 shadow-2xl shadow-black/50">
+            <div className="relative w-full max-w-sm rounded-[48%] border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)] p-10 shadow-2xl shadow-black/50">
               <div className="absolute -top-6 right-0 h-20 w-20 rounded-full bg-[var(--color-rose)]/25 blur-2xl" />
               <div className="absolute -bottom-8 left-6 h-24 w-24 rounded-full bg-[var(--color-gold)]/15 blur-2xl" />
               <div className="space-y-4 text-center">
@@ -136,7 +136,7 @@ export default function AboutPage() {
             {milestones.map((item) => (
               <div key={item.year} className="flex gap-6">
                 <div className="flex-shrink-0">
-                  <div className="rounded-full bg-gradient-to-br from-[var(--color-rose)] to-[var(--color-gold)] px-4 py-2 text-sm font-semibold text-white shadow">
+                  <div className="rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-white shadow">
                     {item.year}
                   </div>
                 </div>
@@ -150,7 +150,7 @@ export default function AboutPage() {
         </div>
       </section>
 
-      <section className="relative bg-gradient-to-r from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.78)] to-[var(--color-burgundy)]">
+      <section className="relative bg-[var(--color-burgundy-dark)]">
         <div className="max-w-screen-xl mx-auto px-6 lg:px-10 py-16 flex flex-col gap-10 lg:flex-row lg:items-center">
           <div className="flex-1 space-y-4">
             <h2 className="text-3xl font-bold text-[var(--color-choco)]">มารู้จักทีมของเรา</h2>

--- a/app/(site)/cart/page.jsx
+++ b/app/(site)/cart/page.jsx
@@ -251,7 +251,7 @@ export default function CartPage() {
       <div className="mt-6 flex flex-col gap-3">
         <Link
           href="/checkout"
-          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
         >
           ไปหน้าชำระเงิน
         </Link>
@@ -296,7 +296,7 @@ export default function CartPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_60%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(135deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 right-8 h-64 w-64 rounded-full bg-[var(--color-rose)]/25 blur-3xl" />
       <div className="absolute -bottom-20 left-0 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/25 blur-3xl" />
 
@@ -371,7 +371,7 @@ export default function CartPage() {
                           </div>
                         </div>
                         <button
-                          className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/35 bg-gradient-to-r from-[var(--color-rose)]/20 to-[var(--color-rose-dark)]/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-rose)] transition hover:from-[var(--color-rose)]/35 hover:to-[var(--color-rose-dark)]/35 hover:text-[var(--color-gold)]"
+                          className="inline-flex items-center gap-2 rounded-full border border-[var(--color-rose)]/35 bg-[var(--color-rose)]/15 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-rose)] transition hover:bg-[var(--color-rose)]/25 hover:text-[var(--color-gold)]"
                           onClick={() => cart.remove(it.productId)}
                         >
                           <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[var(--color-rose)] text-[var(--color-burgundy-dark)] shadow-md shadow-[rgba(0,0,0,0.35)]">
@@ -413,7 +413,7 @@ export default function CartPage() {
                     <button
                       onClick={applyCoupon}
                       disabled={applying}
-                      className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {applying ? "กำลังตรวจสอบ..." : "ใช้คูปอง"}
                     </button>

--- a/app/(site)/checkout/page.jsx
+++ b/app/(site)/checkout/page.jsx
@@ -312,7 +312,7 @@ export default function CheckoutPage() {
 
   return (
     <main className="relative min-h-screen overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.9)] to-[var(--color-burgundy)]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 left-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/18 blur-3xl" />
       <div className="absolute -bottom-28 right-10 h-72 w-72 rounded-full bg-[var(--color-gold)]/18 blur-3xl" />
 
@@ -406,7 +406,7 @@ export default function CheckoutPage() {
                 className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                   creating || cart.items.length === 0 || order
                     ? "bg-[var(--color-burgundy-dark)]/40 cursor-not-allowed"
-                    : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] hover:shadow-xl"
+                    : "bg-[var(--color-rose)] hover:shadow-xl"
                 }`}
               >
                 {order
@@ -578,7 +578,7 @@ export default function CheckoutPage() {
                     className={`inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] transition ${
                       confirming || updatingMethod || !slipData || (needsPayment && !transferAmount)
                         ? "bg-[var(--color-burgundy-dark)]/40 cursor-not-allowed"
-                        : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
+                        : "bg-[var(--color-rose)] hover:shadow-xl"
                     }`}
                   >
                     {confirming ? "กำลังยืนยัน..." : updatingMethod ? "กำลังอัปเดตวิธีชำระเงิน..." : "ยืนยันการชำระเงิน"}

--- a/app/(site)/hook/page.jsx
+++ b/app/(site)/hook/page.jsx
@@ -5,7 +5,7 @@ export default function HookPage({ searchParams }) {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.88)] to-[var(--color-burgundy)]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-28 left-16 h-72 w-72 rounded-full bg-[var(--color-gold)]/15 blur-3xl" />
 
@@ -26,7 +26,7 @@ export default function HookPage({ searchParams }) {
 
           <Link
             href="/"
-            className="mt-8 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:shadow-xl"
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[rgba(240,200,105,0.33)] hover:shadow-xl"
           >
             กลับสู่หน้าหลัก
           </Link>

--- a/app/(site)/login/page.js
+++ b/app/(site)/login/page.js
@@ -35,7 +35,7 @@ function LoginContent() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[var(--color-cream-soft)]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 right-20 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-28 left-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
@@ -71,7 +71,7 @@ function LoginContent() {
             </div>
             <button
               disabled={loading}
-              className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
+              className="w-full rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
             >
               {loading ? "กำลังเข้าสู่ระบบ..." : "เข้าสู่ระบบ"}
             </button>

--- a/app/(site)/orders/[id]/page.jsx
+++ b/app/(site)/orders/[id]/page.jsx
@@ -382,7 +382,7 @@ export default function OrderDetailPage() {
   if (needsAuth && status !== "loading") {
     return (
       <main className="relative min-h-[70vh] overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+        <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
           <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 p-10 text-center text-[var(--color-text)] shadow-2xl shadow-black/40 backdrop-blur">
             <h1 className="text-2xl font-semibold text-[var(--color-rose)]">เข้าสู่ระบบก่อนดูรายละเอียด</h1>
@@ -392,7 +392,7 @@ export default function OrderDetailPage() {
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
               >
                 เข้าสู่ระบบ
               </Link>
@@ -428,7 +428,7 @@ export default function OrderDetailPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.65),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 right-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-20 left-20 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
@@ -450,7 +450,7 @@ export default function OrderDetailPage() {
           </div>
           <Link
             href="/orders"
-            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-2 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
           >
             ← กลับไปหน้ารายการทั้งหมด
           </Link>
@@ -693,7 +693,7 @@ export default function OrderDetailPage() {
                             <p>แนบรูปสลิปเพื่อยืนยันการโอนเงิน (รองรับไฟล์ .jpg, .png)</p>
                             <label
                               htmlFor="slip"
-                              className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-4 py-2 text-xs font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(240,200,105,0.35)] transition hover:shadow-xl"
+                              className="inline-flex cursor-pointer items-center justify-center gap-2 rounded-full bg-[var(--color-rose)] px-4 py-2 text-xs font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(240,200,105,0.35)] transition hover:shadow-xl"
                             >
                               <UploadIcon className="h-4 w-4" />
                               แนบสลิปการโอน
@@ -741,7 +741,7 @@ export default function OrderDetailPage() {
                           !slipData ||
                           (needsAmountInput && !transferAmount)
                             ? "cursor-not-allowed bg-[var(--color-burgundy-dark)]/30"
-                            : "bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] hover:shadow-xl"
+                            : "bg-[var(--color-rose)] hover:shadow-xl"
                         }`}
                       >
                         {confirming

--- a/app/(site)/orders/page.jsx
+++ b/app/(site)/orders/page.jsx
@@ -112,7 +112,7 @@ export default function OrdersPage() {
   if (needsAuth && status !== "loading") {
     return (
       <main className="relative min-h-[70vh] overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.7),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+        <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
         <div className="relative flex min-h-[60vh] items-center justify-center px-6 py-16">
           <div className="w-full max-w-md rounded-3xl border border-[var(--color-rose)]/25 bg-[var(--color-burgundy)]/75 p-10 text-center text-[var(--color-text)] shadow-2xl shadow-black/40 backdrop-blur">
             <h1 className="text-2xl font-semibold text-[var(--color-rose)]">เข้าสู่ระบบเพื่อดูคำสั่งซื้อ</h1>
@@ -122,7 +122,7 @@ export default function OrdersPage() {
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
-                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] hover:shadow-xl"
               >
                 เข้าสู่ระบบ
               </Link>
@@ -148,7 +148,7 @@ export default function OrdersPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(58,16,16,0.65),transparent_55%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 right-20 h-60 w-60 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-20 left-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
@@ -162,7 +162,7 @@ export default function OrdersPage() {
           </div>
           <Link
             href="/"
-            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
+            className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-5 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition hover:shadow-xl"
           >
             เลือกสินค้าเพิ่ม
           </Link>

--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -45,7 +45,7 @@ export default async function HomePage() {
   return (
     <main className="min-h-screen">
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[#5d1f1f]" />
+        <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
         <div className="absolute -top-20 -right-10 h-72 w-72 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
         <div className="absolute -bottom-16 -left-16 h-64 w-64 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
@@ -95,7 +95,7 @@ export default async function HomePage() {
           </div>
 
           <div className="relative flex justify-center">
-            <div className="relative h-[320px] w-[320px] sm:h-[360px] sm:w-[360px] rounded-[48%] bg-gradient-to-br from-[var(--color-burgundy)] via-[#3c1212] to-[var(--color-burgundy-dark)] shadow-2xl shadow-black/50 flex items-center justify-center">
+            <div className="relative h-[320px] w-[320px] sm:h-[360px] sm:w-[360px] rounded-[48%] bg-[var(--color-burgundy)] shadow-2xl shadow-black/50 flex items-center justify-center">
               <div className="absolute -top-8 right-8 h-16 w-16 rounded-full bg-[var(--color-rose)]/30 shadow-lg shadow-[var(--color-rose)]/40" />
               <div className="absolute -bottom-6 left-10 h-20 w-20 rounded-full bg-[var(--color-rose-dark)]/30 shadow-lg shadow-[var(--color-rose-dark)]/40" />
               <div className="absolute top-10 left-6 h-12 w-12 rounded-full border-4 border-dashed border-[var(--color-rose)]/50" />
@@ -118,7 +118,7 @@ export default async function HomePage() {
 
 
       <section id="menu" className="relative overflow-hidden py-16">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_80%_20%,rgba(58,16,16,0.7),transparent_60%),linear-gradient(135deg,rgba(20,2,2,0.9),rgba(76,25,18,0.85))]" />
+        <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
         <div className="relative mx-auto flex max-w-screen-xl flex-col gap-12 px-6 lg:px-8">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
@@ -152,7 +152,7 @@ export default async function HomePage() {
                   className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-[var(--color-rose)]/20 bg-[var(--color-burgundy)]/75 shadow-lg shadow-black/40 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
                 >
                   <div className="relative overflow-hidden">
-                    <div className="aspect-square w-full bg-[radial-gradient(circle_at_30%_30%,rgba(240,200,105,0.25),rgba(58,16,16,0.65))] flex items-center justify-center">
+                    <div className="aspect-square w-full bg-[var(--color-burgundy)] flex items-center justify-center">
                       {p.images?.[0] ? (
                         <img
                           src={p.images[0]}
@@ -200,7 +200,7 @@ export default async function HomePage() {
       </section>
 
       <section className="relative overflow-hidden py-16">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_25%,rgba(240,200,105,0.1),transparent_55%),radial-gradient(circle_at_85%_15%,rgba(193,138,29,0.2),transparent_60%),linear-gradient(160deg,rgba(20,2,2,0.95),rgba(58,16,16,0.85))]" />
+        <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
         <div className="relative mx-auto grid max-w-screen-xl gap-10 px-6 py-10 text-[var(--color-text)] md:grid-cols-3 lg:px-8">
           {["ทำสดใหม่ทุกวัน", "ทำเองทุกขั้นตอน", "เลือกวัตถุดิบคุณภาพ"].map(
             (title, idx) => (
@@ -208,7 +208,7 @@ export default async function HomePage() {
                 key={title}
                 className="rounded-3xl border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/75 p-8 shadow-lg shadow-black/30 backdrop-blur"
               >
-                {/* <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-[var(--color-rose)] to-[var(--color-gold)] text-white text-xl shadow">
+                {/* <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-rose)] text-white text-xl shadow">
                   {idx === 0 ? "👩‍🍳" : idx === 1 ? "👐" : "🌾"}
                 </div> */}
                 <h3 className="text-xl font-semibold text-[var(--color-rose)]">

--- a/app/(site)/preorder/page.jsx
+++ b/app/(site)/preorder/page.jsx
@@ -90,7 +90,7 @@ export default function PreOrderPage() {
   return (
     <div className="relative overflow-hidden">
       <div
-        className="absolute inset-0 bg-gradient-to-b from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.9)] to-[var(--color-burgundy)]"
+        className="absolute inset-0 bg-[var(--color-burgundy-dark)]"
         aria-hidden
       />
 
@@ -126,7 +126,7 @@ export default function PreOrderPage() {
             </div>
           </div>
           <div className="flex-1">
-            <div className="rounded-[46%] border border-[var(--color-rose)]/30 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[rgba(58,16,16,0.85)] to-[var(--color-burgundy)] p-10 text-center shadow-2xl shadow-black/45">
+            <div className="rounded-[46%] border border-[var(--color-rose)]/30 bg-[var(--color-burgundy-dark)] p-10 text-center shadow-2xl shadow-black/45">
               <p className="text-sm font-semibold tracking-[0.3em] uppercase text-[var(--color-rose)]">Made to Order</p>
               <p className="mt-3 text-3xl font-black text-[var(--color-choco)]">Pre-order ขนมชิ้นโปรด</p>
               <p className="mt-4 text-sm text-[var(--color-choco)]/70">
@@ -295,7 +295,7 @@ export default function PreOrderPage() {
             <button
               type="submit"
               disabled={submitting}
-              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-8 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/45 transition hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-8 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-black/45 transition hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอออกแบบเมนู"}
             </button>
@@ -343,7 +343,7 @@ export default function PreOrderPage() {
               </div>
             </a>
           </div>
-          <div className="rounded-3xl bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-gold)] px-5 py-6 text-white shadow-lg shadow-[rgba(240,200,105,0.33)]">
+          <div className="rounded-3xl bg-[var(--color-gold)] px-5 py-6 text-white shadow-lg shadow-[rgba(240,200,105,0.33)]">
             <p className="text-sm font-semibold uppercase tracking-[0.2em]">Tip</p>
             <p className="mt-2 text-sm">
               หากมี moodboard หรือรูปตัวอย่างที่ชื่นชอบ สามารถแนบส่งผ่านอีเมลหรือ LINE หลังจากกรอกแบบฟอร์มเพื่อให้ทีมออกแบบได้แม่นยำขึ้น

--- a/app/(site)/profile/page.jsx
+++ b/app/(site)/profile/page.jsx
@@ -153,7 +153,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <main className="relative overflow-hidden bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[var(--color-cream-soft)]">
+    <main className="relative overflow-hidden bg-[var(--color-burgundy-dark)]">
       <div className="absolute inset-0 opacity-40">
         <div className="absolute -top-20 left-16 h-72 w-72 rounded-full bg-[var(--color-rose)]/30 blur-3xl" />
         <div className="absolute -bottom-24 right-16 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/30 blur-3xl" />
@@ -250,7 +250,7 @@ export default function ProfilePage() {
                   <button
                     type="submit"
                     disabled={saving || !isDirty}
-                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center justify-center rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {saving ? "กำลังบันทึก..." : "บันทึกการเปลี่ยนแปลง"}
                   </button>

--- a/app/(site)/register/page.js
+++ b/app/(site)/register/page.js
@@ -28,7 +28,7 @@ export default function RegisterPage() {
 
   return (
     <main className="relative min-h-[70vh] overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[var(--color-cream-soft)]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="absolute -top-24 left-16 h-64 w-64 rounded-full bg-[var(--color-rose)]/20 blur-3xl" />
       <div className="absolute -bottom-28 right-12 h-72 w-72 rounded-full bg-[var(--color-rose-dark)]/20 blur-3xl" />
 
@@ -74,7 +74,7 @@ export default function RegisterPage() {
             </div>
             <button
               disabled={loading}
-              className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
+              className="w-full rounded-full bg-[var(--color-rose)] px-6 py-3 text-sm font-semibold text-[var(--color-burgundy-dark)] shadow-lg shadow-[rgba(0,0,0,0.35)] transition disabled:cursor-not-allowed disabled:opacity-70"
             >
               {loading ? "กำลังสมัคร..." : "สมัครสมาชิก"}
             </button>

--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -7,7 +7,7 @@ export const metadata = { title: "Admin | Sweet Cravings" };
 export default function AdminLayout({ children }) {
   return (
     <AdminPopupProvider>
-      <div className="relative min-h-screen bg-[radial-gradient(circle_at_15%_20%,#4f1818,transparent_55%),radial-gradient(circle_at_80%_0%,#2b0c0c,transparent_50%),radial-gradient(circle_at_100%_80%,#180404,transparent_45%)] text-[var(--color-gold)] lg:flex">
+      <div className="relative min-h-screen bg-[var(--color-burgundy-dark)] text-[var(--color-gold)] lg:flex">
         <AdminSidebar />
 
         <main className="flex-1 lg:ml-0">

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -145,7 +145,7 @@ export default function AdminUsersPage() {
 
   return (
     <div className="space-y-10">
-      <section className="rounded-[30px] border border-[rgba(229,189,119,0.38)] bg-gradient-to-br from-[rgba(68,46,30,0.92)] via-[rgba(46,30,20,0.88)] to-[rgba(27,18,12,0.9)] p-6 shadow-[0_34px_68px_-32px_rgba(12,8,4,0.85)] backdrop-blur-xl">
+      <section className="rounded-[30px] border border-[rgba(229,189,119,0.38)] bg-[rgba(46,30,20,0.9)] p-6 shadow-[0_34px_68px_-32px_rgba(12,8,4,0.85)] backdrop-blur-xl">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-xl space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[rgba(229,189,119,0.68)]">Sweet Cravings Admin</p>
@@ -176,24 +176,24 @@ export default function AdminUsersPage() {
             label="ผู้ใช้ทั้งหมด"
             helper="จำนวนผู้ใช้งานทั้งหมด"
             value={stats.total}
-            tone="from-[rgba(229,189,119,0.28)] via-[rgba(229,189,119,0.12)] to-[rgba(80,52,34,0.32)]"
+            tone="bg-[rgba(229,189,119,0.28)]"
           />
           <StatCard
             label="ผู้ดูแลระบบ"
             helper="สิทธิ์เข้าจัดการหลังบ้าน"
             value={stats.adminCount}
-            tone="from-[rgba(124,209,184,0.32)] via-[rgba(229,189,119,0.16)] to-[rgba(36,66,56,0.35)]"
+            tone="bg-[rgba(124,209,184,0.32)]"
           />
           <StatCard
             label="ถูกระงับ"
             helper="บัญชีที่ปิดใช้งานชั่วคราว"
             value={stats.bannedCount}
-            tone="from-[rgba(239,120,120,0.35)] via-[rgba(229,189,119,0.16)] to-[rgba(82,34,28,0.35)]"
+            tone="bg-[rgba(239,120,120,0.35)]"
           />
         </div>
       </section>
 
-      <section className="overflow-hidden rounded-[34px] border border-[rgba(229,189,119,0.32)] bg-gradient-to-b from-[rgba(44,30,20,0.92)] via-[rgba(32,22,15,0.88)] to-[rgba(20,14,9,0.85)] shadow-[0_34px_64px_-34px_rgba(10,6,2,0.9)] backdrop-blur-xl">
+      <section className="overflow-hidden rounded-[34px] border border-[rgba(229,189,119,0.32)] bg-[rgba(32,22,15,0.88)] shadow-[0_34px_64px_-34px_rgba(10,6,2,0.9)] backdrop-blur-xl">
         <header className="flex flex-col gap-3 border-b border-[rgba(229,189,119,0.18)] bg-[rgba(26,18,12,0.72)] px-6 py-6 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-xl font-semibold text-[var(--color-text)]">รายการผู้ใช้งาน</h3>
@@ -309,7 +309,7 @@ export default function AdminUsersPage() {
             <div className="hidden overflow-x-auto lg:block">
               <table className="min-w-full text-sm text-[rgba(229,189,119,0.86)]">
                 <thead>
-                  <tr className="border-b border-[rgba(229,189,119,0.22)] bg-gradient-to-r from-[rgba(229,189,119,0.16)] via-[rgba(229,189,119,0.12)] to-[rgba(229,189,119,0.16)] text-[var(--color-text)]">
+                  <tr className="border-b border-[rgba(229,189,119,0.22)] bg-[rgba(229,189,119,0.16)] text-[var(--color-text)]">
                     <th className="px-6 py-4 text-left text-sm font-semibold tracking-wide">
                       <div className="flex items-center gap-2">
                         👤 ชื่อผู้ใช้
@@ -381,8 +381,8 @@ export default function AdminUsersPage() {
                               <div
                                 className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold shadow-[0_10px_22px_-16px_rgba(8,5,2,0.85)] ${
                                   user.role === 'admin'
-                                    ? 'bg-gradient-to-br from-[rgba(124,209,184,0.55)] to-[rgba(82,168,142,0.8)] text-[rgba(8,18,14,0.9)]'
-                                    : 'bg-gradient-to-br from-[rgba(229,189,119,0.6)] to-[rgba(214,167,94,0.82)] text-[rgba(29,20,13,0.95)]'
+                                    ? 'bg-[rgba(124,209,184,0.55)] text-[rgba(8,18,14,0.9)]'
+                                    : 'bg-[rgba(229,189,119,0.6)] text-[rgba(29,20,13,0.95)]'
                                 }`}
                               >
                                 {user.role === 'admin' ? '👑' : '👤'}
@@ -481,7 +481,7 @@ export default function AdminUsersPage() {
 function StatCard({ label, helper, value, tone }) {
   return (
     <div className="relative overflow-hidden rounded-[26px] border border-[rgba(229,189,119,0.26)] bg-[rgba(27,18,12,0.78)] p-5 text-left shadow-[0_24px_48px_-30px_rgba(9,6,3,0.92)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_32px_52px_-26px_rgba(9,6,3,0.94)]">
-      <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${tone} opacity-80`} aria-hidden />
+      <div className={`pointer-events-none absolute inset-0 ${tone} opacity-80`} aria-hidden />
       <div className="relative space-y-2">
         <p className="text-xs font-semibold uppercase tracking-wide text-[rgba(229,189,119,0.7)]">{label}</p>
         <p className="text-3xl font-semibold text-[var(--color-text)]">{value}</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,18 +4,18 @@
 @tailwind utilities;
 
 :root {
-  --color-cream: #a2805d;
-  --color-cream-soft: #8f694b;
-  --color-rose: #e5bd77;
-  --color-rose-dark: #d1a15f;
-  --color-gold: #f4dab0;
-  --color-text: #e5bd77;
-  --color-choco: #f9e8c7;
-  --color-burgundy: #7a573f;
-  --color-burgundy-soft: #6a4b37;
-  --color-burgundy-dark: #523a29;
-  --surface-strong: rgba(82, 58, 41, 0.82);
-  --surface-soft: rgba(106, 75, 55, 0.66);
+  --color-cream: #ffe6cf;
+  --color-cream-soft: #ffd0a8;
+  --color-rose: #ff6f7b;
+  --color-rose-dark: #ff4c68;
+  --color-gold: #14a899;
+  --color-text: #1f3a37;
+  --color-choco: #fff3e1;
+  --color-burgundy: #1fbba9;
+  --color-burgundy-soft: #1da394;
+  --color-burgundy-dark: #137369;
+  --surface-strong: rgba(255, 255, 255, 0.95);
+  --surface-soft: rgba(255, 255, 255, 0.88);
   --layout-max: 1200px;
 }
 
@@ -26,12 +26,7 @@ body {
 
 body {
   margin: 0;
-  background: radial-gradient(
-    circle at top,
-    #b18f6c 0%,
-    var(--color-cream) 55%,
-    var(--color-burgundy-dark) 100%
-  );
+  background-color: var(--color-cream);
   color: var(--color-text);
   font-family: "Poppins", "Prompt", "Kanit", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -45,46 +40,47 @@ a:hover {
 } */
 
 ::selection {
-  background: rgba(240, 200, 105, 0.35);
+  background: rgba(255, 111, 123, 0.45);
 }
 
 label {
-  color: rgba(229, 189, 119, 0.9);
+  color: rgba(31, 58, 55, 0.75);
 }
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   * {
-    border-color: rgba(229, 189, 119, 0.25);
+    border-color: rgba(31, 58, 55, 0.16);
   }
 
   input,
   textarea,
   select {
-    background-color: rgba(122, 87, 63, 0.55);
+    background-color: rgba(255, 255, 255, 0.94);
     color: var(--color-text);
+    border-radius: 14px;
   }
 
   input::placeholder,
   textarea::placeholder {
-    color: rgba(229, 189, 119, 0.65);
+    color: rgba(31, 58, 55, 0.5);
   }
 }
 
 :is(.bg-white, .bg-white\/95, .bg-white\/90, .bg-white\/85) {
   background-color: var(--surface-strong) !important;
   color: var(--color-text) !important;
-  border-color: rgba(229, 189, 119, 0.24) !important;
-  box-shadow: 0 22px 46px -32px rgba(25, 16, 9, 0.72);
-  backdrop-filter: blur(14px);
+  border-color: rgba(31, 58, 55, 0.12) !important;
+  box-shadow: 0 22px 46px -28px rgba(15, 87, 79, 0.35);
+  backdrop-filter: blur(16px);
 }
 
 :is(.bg-white\/80, .bg-white\/70, .bg-white\/60) {
   background-color: var(--surface-soft) !important;
   color: var(--color-text) !important;
-  border-color: rgba(229, 189, 119, 0.18) !important;
-  backdrop-filter: blur(12px);
+  border-color: rgba(31, 58, 55, 0.1) !important;
+  backdrop-filter: blur(14px);
 }

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -35,7 +35,7 @@ export default function AddToCartButton({ product }) {
 
   return (
     <button
-      className="px-4 py-2 rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] text-[var(--color-burgundy-dark)] text-sm font-semibold shadow-lg shadow-[rgba(240,200,105,0.33)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+      className="px-4 py-2 rounded-full bg-[var(--color-rose)] text-[var(--color-burgundy-dark)] text-sm font-semibold shadow-lg shadow-[rgba(240,200,105,0.33)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
       onClick={handleClick}
     >
       {saleMode === "preorder" ? "สั่ง Pre-order" : "เพิ่มลงตะกร้า"}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -24,7 +24,7 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="mt-20 bg-gradient-to-br from-[var(--color-burgundy-dark)] via-[var(--color-burgundy)] to-[var(--color-burgundy-soft)] text-[var(--color-gold)]">
+    <footer className="mt-20 bg-[var(--color-burgundy-dark)] text-[var(--color-gold)]">
       <div className="relative">
         {/* <div className="absolute -top-6 left-6 hidden rotate-6 text-5xl opacity-40 md:block">
           🥐

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -116,7 +116,7 @@ export default function NavBar() {
       </div>
 
       <nav className="shadow-[0_20px_40px_-20px_rgba(0,0,0,0.6)]">
-        <div className="bg-gradient-to-r from-[var(--color-burgundy-soft)] via-[var(--color-cream-soft)] to-[var(--color-burgundy-soft)]">
+        <div className="bg-[var(--color-cream-soft)]">
           <div className="max-w-screen-xl mx-auto flex items-center justify-between gap-6 px-4 py-4 sm:px-6">
             <Link
               href="/"

--- a/components/QrBox.jsx
+++ b/components/QrBox.jsx
@@ -78,7 +78,7 @@ export default function QrBox({ payload, amount, title = "สแกนจ่า�
   </div> */}
 
   <button
-    className="w-full rounded-full bg-gradient-to-r from-[var(--color-rose)] to-[var(--color-rose-dark)] px-4 py-2 text-sm font-semibold text-white shadow shadow-[rgba(240,200,105,0.33)] transition hover:shadow-md"
+    className="w-full rounded-full bg-[var(--color-rose)] px-4 py-2 text-sm font-semibold text-white shadow shadow-[rgba(240,200,105,0.33)] transition hover:shadow-md"
     onClick={saveQrCode}
     type="button"
   >

--- a/components/ReviewsShowcase.jsx
+++ b/components/ReviewsShowcase.jsx
@@ -351,7 +351,7 @@ export default function ReviewsShowcase({ reviews: initialReviews = [] }) {
 
   return (
     <section className="relative overflow-hidden py-16">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_0%_0%,rgba(240,200,105,0.12),transparent_55%),radial-gradient(circle_at_90%_10%,rgba(58,16,16,0.7),transparent_60%),linear-gradient(140deg,rgba(20,2,2,0.95),rgba(76,25,18,0.85))]" />
+      <div className="absolute inset-0 bg-[var(--color-burgundy-dark)]" />
       <div className="relative mx-auto max-w-screen-xl px-6 lg:px-8">
         <div className="rounded-[2.5rem] border border-[var(--color-rose)]/15 bg-[var(--color-burgundy)]/80 p-8 shadow-2xl shadow-black/40 backdrop-blur">
           <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[1.4fr_0.9fr] lg:items-start">

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -69,7 +69,7 @@ export default function AdminSidebar() {
 
       <aside
         id="admin-sidebar"
-        className={`fixed inset-y-0 left-0 z-50 w-72 origin-left transform bg-gradient-to-b from-[var(--color-burgundy)] via-[var(--color-burgundy-dark)] to-[#090101] text-[var(--color-gold)] shadow-[12px_0_40px_-16px_rgba(0,0,0,0.6)] transition-transform duration-300 ease-in-out lg:static lg:block lg:h-auto lg:w-72 lg:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-50 w-72 origin-left transform bg-[var(--color-burgundy-dark)] text-[var(--color-gold)] shadow-[12px_0_40px_-16px_rgba(0,0,0,0.6)] transition-transform duration-300 ease-in-out lg:static lg:block lg:h-auto lg:w-72 lg:translate-x-0 ${
           open ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
         }`}
       >


### PR DESCRIPTION
## Summary
- replace hero and section backdrops across the storefront with solid brand colors to eliminate gradients
- update shared buttons and promo chips to use flat fills that align with the refreshed palette
- simplify admin dashboard surfaces and stat overlays to rely on single-tone backgrounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da2f67a9d4832db5f66f635820f91c