### PR TITLE
Fix checkout payment section conditional rendering

### DIFF
--- a/app/(site)/checkout/page.jsx
+++ b/app/(site)/checkout/page.jsx
@@ -394,6 +394,7 @@ export default function CheckoutPage() {
                   );
                 })}
               </div>
+              {order ? (
                 <p className="text-xs text-[#3c1a09]/60">
                   สร้างคำสั่งซื้อแล้ว สามารถสลับวิธีการชำระเงินได้ตลอดโดยไม่ต้องสร้างคำสั่งซื้อใหม่
                 </p>


### PR DESCRIPTION
## Summary
- fix JSX syntax error in checkout payment method section by wrapping the post-order notice in a conditional
- ensure the informational message only renders when an order exists, restoring successful builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da4be8dd94832d8fb97d4e5f60d5b7