### PR TITLE
Add stock deduction when orders are created

### DIFF
--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -22,6 +22,7 @@ export async function GET() {
 }
 
 export async function POST(req) {
+  let deductedStock = [];
   try {
     const { items, payment = { method: "promptpay" } } = await req.json();
     if (!Array.isArray(items) || items.length === 0) {
@@ -33,7 +34,9 @@ export async function POST(req) {
     const docs = await Product.find({ _id: { $in: ids }, active: true }).lean();
     const byId = Object.fromEntries(docs.map((d) => [String(d._id), d]));
     for (const it of items) {
-      if (!byId[it.productId]) return NextResponse.json({ error: `Product not found: ${it.productId}` }, { status: 400 });
+      if (!byId[it.productId]) {
+        return NextResponse.json({ error: `Product not found: ${it.productId}` }, { status: 400 });
+      }
     }
 
     const checked = items.map((it) => {
@@ -41,6 +44,38 @@ export async function POST(req) {
       const qty = Math.max(1, Number(it.qty || 1));
       return { productId: String(p._id), title: p.title, price: p.price, qty, lineTotal: p.price * qty };
     });
+
+    const insufficientStock = checked.filter((it) => {
+      const product = byId[it.productId];
+      return typeof product.stock === "number" && product.stock < it.qty;
+    });
+    if (insufficientStock.length > 0) {
+      const first = insufficientStock[0];
+      return NextResponse.json(
+        {
+          error: `Insufficient stock for ${first.title}`,
+          productId: first.productId,
+        },
+        { status: 409 },
+      );
+    }
+
+    for (const item of checked) {
+      const product = byId[item.productId];
+      if (typeof product.stock !== "number") continue;
+      const updated = await Product.findOneAndUpdate(
+        { _id: item.productId, stock: { $gte: item.qty } },
+        { $inc: { stock: -item.qty } },
+      ).lean();
+      if (!updated) {
+        const err = new Error(`Insufficient stock for ${item.productId}`);
+        err.code = "INSUFFICIENT_STOCK";
+        err.productId = item.productId;
+        err.productTitle = product.title;
+        throw err;
+      }
+      deductedStock.push({ productId: item.productId, qty: item.qty });
+    }
 
     const subtotal = checked.reduce((n, x) => n + x.lineTotal, 0);
     const discount = 0;
@@ -70,6 +105,24 @@ export async function POST(req) {
 
     return NextResponse.json({ ok: 1, id: String(order._id) }, { status: 201 });
   } catch (e) {
+    if (deductedStock.length > 0) {
+      await Promise.allSettled(
+        deductedStock.map((item) =>
+          Product.updateOne({ _id: item.productId }, { $inc: { stock: item.qty } }),
+        ),
+      );
+    }
+
+    if (e?.code === "INSUFFICIENT_STOCK") {
+      return NextResponse.json(
+        {
+          error: e.productTitle ? `Insufficient stock for ${e.productTitle}` : "Insufficient stock",
+          productId: e.productId,
+        },
+        { status: 409 },
+      );
+    }
+
     return NextResponse.json({ error: String(e) }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- validate available stock before accepting an order
- decrement product stock when an order is created and restore it if creation fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3460b60c832daedc7dfb742dc719