### PR TITLE
Add product cost tracking and profit analytics

### DIFF
--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -8,8 +8,17 @@ import {
   adminSurfaceShell,
 } from "@/app/admin/theme";
 
+const formatCurrency = (value) =>
+  Number(value || 0).toLocaleString("th-TH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+const formatInteger = (value) => Number(value || 0).toLocaleString("th-TH");
+
 const statusChips = [
   { key: "todaySales", label: "ยอดขายวันนี้", prefix: "฿" },
+  { key: "todayProfit", label: "กำไรวันนี้", prefix: "฿" },
   { key: "preorderPipeline", label: "ใบเสนอราคาวันนี้", prefix: "฿" },
   { key: "newOrders", label: "ออเดอร์ใหม่", prefix: "" },
   { key: "lowStock", label: "สินค้าใกล้หมด", prefix: "" },
@@ -72,7 +81,41 @@ export default function AdminDashboardPage() {
       </section>
     );
 
-  const { cards, topProducts } = data;
+  const { cards, topProducts, profitSummary = {} } = data;
+
+  const now = useMemo(() => new Date(), []);
+  const monthLabel = useMemo(() => {
+    try {
+      return new Intl.DateTimeFormat("th-TH", {
+        month: "long",
+        year: "numeric",
+      }).format(now);
+    } catch (error) {
+      return "เดือนนี้";
+    }
+  }, [now]);
+
+  const defaultSummary = { revenue: 0, cost: 0, profit: 0 };
+  const profitTiles = [
+    {
+      key: "today",
+      title: "รายวัน",
+      subtitle: "ตั้งแต่ 00:00 น.",
+      summary: profitSummary.today ?? defaultSummary,
+    },
+    {
+      key: "week",
+      title: "7 วันล่าสุด",
+      subtitle: "รวมยอดตั้งแต่วันนี้ย้อนหลัง",
+      summary: profitSummary.week ?? defaultSummary,
+    },
+    {
+      key: "month",
+      title: monthLabel,
+      subtitle: "ยอดสะสมตั้งแต่ต้นเดือน",
+      summary: profitSummary.month ?? defaultSummary,
+    },
+  ];
 
   return (
     <div className="space-y-8 text-[#3F2A1A]">
@@ -86,50 +129,89 @@ export default function AdminDashboardPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
-            {statusChips.map((chip) => (
-              <div
-                key={chip.key}
-                className={`${adminSoftBadge} gap-2 px-4 py-2 text-sm shadow-[0_10px_18px_-12px_rgba(63,42,26,0.45)]`}
-              >
-                <span className="font-medium text-[#8A5A33]">{chip.label}</span>
-                <span className="font-semibold text-[#3F2A1A]">
-                  {chip.prefix}
-                  {cards[chip.key]}
-                </span>
-              </div>
-            ))}
+            {statusChips.map((chip) => {
+              const rawValue = cards?.[chip.key] ?? 0;
+              const displayValue =
+                chip.prefix === "฿" ? formatCurrency(rawValue) : formatInteger(rawValue);
+              return (
+                <div
+                  key={chip.key}
+                  className={`${adminSoftBadge} gap-2 px-4 py-2 text-sm shadow-[0_10px_18px_-12px_rgba(63,42,26,0.45)]`}
+                >
+                  <span className="font-medium text-[#8A5A33]">{chip.label}</span>
+                  <span className="font-semibold text-[#3F2A1A]">
+                    {chip.prefix}
+                    {displayValue}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
 
         <div className="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           <StatCard
             title="ยอดขายวันนี้"
-            value={`฿${cards.todaySales}`}
+            value={`฿${formatCurrency(cards.todaySales)}`}
             caption="เปรียบเทียบจากยอดรวมที่ยืนยันแล้ว"
             color="green"
             icon="💰"
           />
           <StatCard
+            title="กำไรวันนี้"
+            value={`฿${formatCurrency(cards.todayProfit)}`}
+            caption="หลังหักต้นทุนสินค้าในวันนี้"
+            color="emerald"
+            icon="📈"
+          />
+          <StatCard
             title="ยอดเสนอราคาใหม่"
-            value={`฿${cards.preorderPipeline}`}
+            value={`฿${formatCurrency(cards.preorderPipeline)}`}
             caption="รวมยอดใบเสนอราคาที่ออกภายในวันนี้"
             color="purple"
             icon="📝"
           />
           <StatCard
             title="ออเดอร์ใหม่"
-            value={cards.newOrders}
+            value={formatInteger(cards.newOrders)}
             caption="ตรวจสอบรายละเอียดก่อน 18:00 น. เพื่อจัดส่งทันวันถัดไป"
             color="blue"
             icon="📦"
           />
           <StatCard
             title="สินค้าใกล้หมด"
-            value={cards.lowStock}
+            value={formatInteger(cards.lowStock)}
             caption="เติมสต็อกล่วงหน้าเพื่อไม่ให้ยอดขายสะดุด"
             color="orange"
             icon="📊"
           />
+        </div>
+      </section>
+
+      <section className={`${adminSubSurfaceShell} p-6`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-xl font-bold text-[#3F2A1A]">สรุปกำไร / ขาดทุน</h3>
+            <p className="text-sm text-[#6F4A2E]">
+              วิเคราะห์รายได้และต้นทุนเพื่อวางแผนยอดขายในแต่ละช่วงเวลา
+            </p>
+          </div>
+          <span className="rounded-full border border-[#E2C39A] bg-white px-4 py-1 text-xs font-semibold text-[#8A5A33]">
+            อัปเดตเรียลไทม์จากคำสั่งซื้อ
+          </span>
+        </div>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
+          {profitTiles.map((tile) => (
+            <ProfitSummaryCard
+              key={tile.key}
+              title={tile.title}
+              subtitle={tile.subtitle}
+              revenue={tile.summary.revenue}
+              cost={tile.summary.cost}
+              profit={tile.summary.profit}
+            />
+          ))}
         </div>
       </section>
 
@@ -156,12 +238,14 @@ export default function AdminDashboardPage() {
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">สินค้า</th>
                     <th className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">จำนวนที่ขาย</th>
                     <th className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">รายได้ (฿)</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">ต้นทุน (฿)</th>
+                    <th className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">กำไร (฿)</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[#F8E7D1]">
                   {topProducts.length === 0 ? (
                     <tr>
-                      <td colSpan={3} className="px-6 py-8 text-center">
+                      <td colSpan={5} className="px-6 py-8 text-center">
                         <div className="flex flex-col items-center">
                           <span className="mb-2 text-4xl">📈</span>
                           <span className="text-[#6F4A2E]">ยังไม่มีข้อมูลยอดขายสำหรับช่วงเวลานี้</span>
@@ -175,8 +259,14 @@ export default function AdminDashboardPage() {
                         className={`transition-colors ${idx % 2 === 0 ? "bg-white" : "bg-[#FFF7EA]"} hover:bg-[#FFEFD8]`}
                       >
                         <td className="px-6 py-4 font-medium text-[#3F2A1A]">{p._id}</td>
-                        <td className="px-6 py-4 text-right text-[#5B3A21]">{p.qty}</td>
-                        <td className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">{p.revenue}</td>
+                        <td className="px-6 py-4 text-right text-[#5B3A21]">{formatInteger(p.qty)}</td>
+                        <td className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">฿{formatCurrency(p.revenue)}</td>
+                        <td className="px-6 py-4 text-right font-semibold text-[#3F2A1A]">฿{formatCurrency(p.cost)}</td>
+                        <td
+                          className={`px-6 py-4 text-right font-semibold ${Number(p.profit || 0) >= 0 ? "text-[#047857]" : "text-[#B91C1C]"}`}
+                        >
+                          ฿{formatCurrency(p.profit)}
+                        </td>
                       </tr>
                     ))
                   )}
@@ -298,6 +388,13 @@ function StatCard({ title, value, caption, color, icon }) {
       value: "text-[#2F2A1F]",
       accent: "bg-[#E8DBFB]",
     },
+    emerald: {
+      bg: "bg-[#ECFDF5]",
+      border: "border-[#BBF7D0]",
+      text: "text-[#047857]",
+      value: "text-[#14532D]",
+      accent: "bg-[#D1FAE5]",
+    },
   };
 
   const config = colorConfig[color] || colorConfig.blue;
@@ -315,6 +412,42 @@ function StatCard({ title, value, caption, color, icon }) {
         <p className={`mb-2 text-3xl font-bold ${config.value}`}>{value}</p>
         <p className="text-xs leading-relaxed text-[#5B3A21]">{caption}</p>
       </div>
+    </div>
+  );
+}
+
+function ProfitSummaryCard({ title, subtitle, revenue = 0, cost = 0, profit = 0 }) {
+  const profitLabel = profit >= 0 ? "กำไร" : "ขาดทุน";
+  const profitTone = profit >= 0 ? "text-[#047857]" : "text-[#B91C1C]";
+  const badgeClass =
+    profit >= 0
+      ? "bg-[#D1FAE5] text-[#047857]"
+      : "bg-[#FEE2E2] text-[#B91C1C]";
+
+  return (
+    <div className={`${adminInsetCardShell} bg-white/95 p-5 shadow-[0_16px_32px_-24px_rgba(63,42,26,0.45)]`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-lg font-semibold text-[#3F2A1A]">{title}</h4>
+          <p className="text-xs text-[#6F4A2E]">{subtitle}</p>
+        </div>
+        <span className={`rounded-full px-3 py-1 text-xs font-semibold ${badgeClass}`}>{profitLabel}</span>
+      </div>
+
+      <dl className="mt-4 space-y-3 text-sm">
+        <div className="flex items-center justify-between text-[#5B3A21]">
+          <dt>รายได้</dt>
+          <dd className="font-semibold text-[#3F2A1A]">฿{formatCurrency(revenue)}</dd>
+        </div>
+        <div className="flex items-center justify-between text-[#5B3A21]">
+          <dt>ต้นทุนสินค้า</dt>
+          <dd className="font-semibold text-[#3F2A1A]">฿{formatCurrency(cost)}</dd>
+        </div>
+        <div className="flex items-center justify-between text-[#5B3A21]">
+          <dt>กำไรสุทธิ</dt>
+          <dd className={`font-semibold ${profitTone}`}>฿{formatCurrency(profit)}</dd>
+        </div>
+      </dl>
     </div>
   );
 }

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -13,6 +13,7 @@ import { useAdminPopup } from "@/components/admin/AdminPopupProvider";
 const emptyProduct = {
   title: "",
   price: 0,
+  costPrice: 0,
   stock: 0,
   description: "",
   image: "",
@@ -26,6 +27,13 @@ const emptyProduct = {
 
 function toSlug(s) {
   return slugify(String(s || ""), { lower: true, strict: true, trim: true });
+}
+
+function formatCurrency(value) {
+  return Number(value || 0).toLocaleString("th-TH", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 function SlidingToggle({ isActive, onToggle, disabled = false }) {
@@ -92,6 +100,7 @@ export default function AdminProductsPage() {
     setForm({
       title: p.title || "",
       price: Number(p.price || 0),
+      costPrice: Number(p.costPrice || 0),
       stock: Number(p.stock || 0),
       description: p.description || "",
       image: Array.isArray(p.images) && p.images[0] ? p.images[0] : "",
@@ -124,6 +133,7 @@ export default function AdminProductsPage() {
       description: form.description,
       images: form.image ? [form.image] : [],
       price: Number(form.price || 0),
+      costPrice: Number(form.costPrice || 0),
       stock: Number(form.stock || 0),
       active: Boolean(form.active),
       tags: String(form.tags || "")
@@ -289,8 +299,9 @@ export default function AdminProductsPage() {
                       <div className="min-w-0 flex-1">
                         <h4 className="truncate font-semibold text-[#3F2A1A]">{p.title}</h4>
                         <p className="truncate text-xs text-[#6F4A2E]">{p.slug}</p>
-                        <div className="mt-2 flex items-center gap-4 text-sm">
-                          <span className="font-semibold text-[#3F2A1A]">฿{p.price}</span>
+                        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+                          <span className="font-semibold text-[#3F2A1A]">ราคาขาย: ฿{formatCurrency(p.price)}</span>
+                          <span className="text-[#5B3A21]">ต้นทุน: ฿{formatCurrency(p.costPrice)}</span>
                           <span className="text-[#5B3A21]">สต็อก: {p.stock}</span>
                         </div>
                         <div className="mt-3 flex items-center justify-between">
@@ -326,6 +337,7 @@ export default function AdminProductsPage() {
                   <tr className="border-b border-[#F3E0C7] bg-[#FFF3E0]">
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">สินค้า</th>
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">ราคา</th>
+                    <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">ต้นทุน</th>
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">สต็อก</th>
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">สถานะ</th>
                     <th className="px-6 py-4 text-left font-semibold text-[#3F2A1A]">แท็ก</th>
@@ -335,7 +347,7 @@ export default function AdminProductsPage() {
                 <tbody className="divide-y divide-[#F3E0C7]">
                   {filteredItems.length === 0 ? (
                     <tr>
-                      <td colSpan={6} className="px-6 py-12 text-center text-[#6F4A2E]">
+                      <td colSpan={7} className="px-6 py-12 text-center text-[#6F4A2E]">
                         <div className="flex flex-col items-center">
                           <span className="mb-4 text-4xl">🛍️</span>
                           <span>ไม่พบสินค้าที่ตรงกับคำค้นหา</span>
@@ -363,7 +375,8 @@ export default function AdminProductsPage() {
                             </div>
                           </div>
                         </td>
-                        <td className="px-6 py-4 font-semibold text-[#3F2A1A]">฿{p.price}</td>
+                        <td className="px-6 py-4 font-semibold text-[#3F2A1A]">฿{formatCurrency(p.price)}</td>
+                        <td className="px-6 py-4 text-[#5B3A21]">฿{formatCurrency(p.costPrice)}</td>
                         <td className="px-6 py-4 text-[#5B3A21]">{p.stock}</td>
                         <td className="px-6 py-4">
                           <div className="flex items-center gap-3">
@@ -439,7 +452,7 @@ export default function AdminProductsPage() {
                     onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
                   />
                 </Field>
-                <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-4 sm:grid-cols-3">
                   <Field label="ราคา">
                     <input
                       type="number"
@@ -447,6 +460,15 @@ export default function AdminProductsPage() {
                       className="w-full rounded-[1rem] border border-[#E2C39A] bg-white px-4 py-2 text-sm text-[#3F2A1A] shadow-[inset_0_1px_3px_rgba(63,42,26,0.12)] focus:border-[#C67C45] focus:outline-none"
                       value={form.price}
                       onChange={(e) => setForm((f) => ({ ...f, price: Number(e.target.value || 0) }))}
+                    />
+                  </Field>
+                  <Field label="ต้นทุนต่อหน่วย">
+                    <input
+                      type="number"
+                      min={0}
+                      className="w-full rounded-[1rem] border border-[#E2C39A] bg-white px-4 py-2 text-sm text-[#3F2A1A] shadow-[inset_0_1px_3px_rgba(63,42,26,0.12)] focus:border-[#C67C45] focus:outline-none"
+                      value={form.costPrice}
+                      onChange={(e) => setForm((f) => ({ ...f, costPrice: Number(e.target.value || 0) }))}
                     />
                   </Field>
                   <Field label="สต็อก">

--- a/app/api/admin/stats/route.js
+++ b/app/api/admin/stats/route.js
@@ -12,11 +12,57 @@ export async function GET() {
 
   await connectToDatabase();
 
-  const todayStart = new Date(); todayStart.setHours(0,0,0,0);
+  const now = new Date();
+  const todayStart = new Date(now);
+  todayStart.setHours(0, 0, 0, 0);
+  const weekStart = new Date(todayStart);
+  weekStart.setDate(weekStart.getDate() - 6);
+  const monthStart = new Date(todayStart);
+  monthStart.setDate(1);
 
-  const [todayAgg, newOrdersCount, lowStockCount, topProducts, preorderToday] = await Promise.all([
+  const activeStatusFilter = { $nin: ["cancel", "cancelled"] };
+  const timeframes = [
+    { key: "today", start: todayStart },
+    { key: "week", start: weekStart },
+    { key: "month", start: monthStart },
+  ];
+
+  const profitPromise = Promise.all(
+    timeframes.map(({ start }) =>
+      Order.aggregate([
+        { $match: { createdAt: { $gte: start }, status: activeStatusFilter } },
+        { $unwind: "$items" },
+        {
+          $group: {
+            _id: null,
+            revenue: { $sum: { $multiply: ["$items.price", "$items.qty"] } },
+            cost: {
+              $sum: {
+                $multiply: [{ $ifNull: ["$items.costPrice", 0] }, "$items.qty"],
+              },
+            },
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            revenue: { $ifNull: ["$revenue", 0] },
+            cost: { $ifNull: ["$cost", 0] },
+            profit: {
+              $subtract: [
+                { $ifNull: ["$revenue", 0] },
+                { $ifNull: ["$cost", 0] },
+              ],
+            },
+          },
+        },
+      ]),
+    ),
+  );
+
+  const [todayAgg, newOrdersCount, lowStockCount, topProducts, preorderToday, profitAggs] = await Promise.all([
     Order.aggregate([
-      { $match: { createdAt: { $gte: todayStart }, status: { $nin: ["cancel", "cancelled"] } } },
+      { $match: { createdAt: { $gte: todayStart }, status: activeStatusFilter } },
       { $group: { _id: null, total: { $sum: "$total" } } },
     ]),
     Order.countDocuments({
@@ -25,9 +71,34 @@ export async function GET() {
     }),
     Product.countDocuments({ stock: { $lt: 5 } }),
     Order.aggregate([
-      { $match: { status: { $nin: ["cancel", "cancelled"] } } },
+      { $match: { status: activeStatusFilter } },
       { $unwind: "$items" },
-      { $group: { _id: "$items.title", qty: { $sum: "$items.qty" }, revenue: { $sum: { $multiply: ["$items.price", "$items.qty"] } } } },
+      {
+        $group: {
+          _id: "$items.title",
+          qty: { $sum: "$items.qty" },
+          revenue: { $sum: { $multiply: ["$items.price", "$items.qty"] } },
+          cost: {
+            $sum: {
+              $multiply: [{ $ifNull: ["$items.costPrice", 0] }, "$items.qty"],
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          profit: { $subtract: ["$revenue", "$cost"] },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          qty: 1,
+          revenue: { $round: ["$revenue", 2] },
+          cost: { $round: ["$cost", 2] },
+          profit: { $round: ["$profit", 2] },
+        },
+      },
       { $sort: { qty: -1 } },
       { $limit: 10 },
     ]),
@@ -45,10 +116,25 @@ export async function GET() {
         },
       },
     ]),
+    profitPromise,
   ]);
+
+  const profitSummary = timeframes.reduce((acc, frame, index) => {
+    const doc = profitAggs?.[index]?.[0] || { revenue: 0, cost: 0, profit: 0 };
+    const revenue = Number(doc.revenue || 0);
+    const cost = Number(doc.cost || 0);
+    const profit = Number(doc.profit != null ? doc.profit : revenue - cost);
+    acc[frame.key] = {
+      revenue: Math.round(revenue * 100) / 100,
+      cost: Math.round(cost * 100) / 100,
+      profit: Math.round(profit * 100) / 100,
+    };
+    return acc;
+  }, {});
 
   const todaySales = todayAgg?.[0]?.total || 0;
   const preorderPipeline = preorderToday?.[0]?.total || 0;
+  const todayProfit = profitSummary.today?.profit || 0;
 
   return NextResponse.json({
     cards: {
@@ -56,7 +142,9 @@ export async function GET() {
       newOrders: newOrdersCount,
       lowStock: lowStockCount,
       preorderPipeline,
+      todayProfit,
     },
     topProducts,
+    profitSummary,
   });
 }

--- a/app/api/checkout/preview/route.js
+++ b/app/api/checkout/preview/route.js
@@ -42,10 +42,18 @@ export async function POST(req) {
       const p = byId[it.productId];
       if (!p) return NextResponse.json({ error: `Product not found: ${it.productId}` }, { status: 400 });
       const qty = Math.max(1, Number(it.qty || 1));
-      checked.push({ productId: String(p._id), title: p.title, price: p.price, qty, lineTotal: p.price * qty });
+      checked.push({
+        productId: String(p._id),
+        title: p.title,
+        price: p.price,
+        qty,
+        costPrice: Number(p.costPrice || 0),
+        lineTotal: p.price * qty,
+      });
     }
 
     const subtotal = checked.reduce((n, x) => n + x.lineTotal, 0);
+    const publicItems = checked.map(({ costPrice, ...rest }) => rest);
 
     let coupon = null;
     if (couponCode) {
@@ -99,7 +107,7 @@ export async function POST(req) {
         ok: 1,
         method,
         orderPreview: {
-          items: checked,
+          items: publicItems,
           subtotal,
           discount,
           total,
@@ -124,7 +132,7 @@ export async function POST(req) {
         ok: 1,
         method,
         orderPreview: {
-          items: checked,
+          items: publicItems,
           subtotal,
           discount,
           total,

--- a/app/api/dev/seed/route.js
+++ b/app/api/dev/seed/route.js
@@ -8,9 +8,33 @@ export async function POST() {
   // เคลียร์ก่อนแล้วใส่ใหม่
   await Product.deleteMany({});
   await Product.insertMany([
-    { title: "Bun Original", slug: "bun-original", description: "นุ่ม หอม", price: 49, stock: 50, active: true },
-    { title: "Bun Creamy",   slug: "bun-creamy",   description: "ครีมหอมมัน", price: 59, stock: 30, active: true },
-    { title: "Bun Choco",    slug: "bun-choco",    description: "ช็อคเข้มข้น", price: 69, stock: 20, active: true },
+    {
+      title: "Bun Original",
+      slug: "bun-original",
+      description: "นุ่ม หอม",
+      price: 49,
+      costPrice: 28,
+      stock: 50,
+      active: true,
+    },
+    {
+      title: "Bun Creamy",
+      slug: "bun-creamy",
+      description: "ครีมหอมมัน",
+      price: 59,
+      costPrice: 33,
+      stock: 30,
+      active: true,
+    },
+    {
+      title: "Bun Choco",
+      slug: "bun-choco",
+      description: "ช็อคเข้มข้น",
+      price: 69,
+      costPrice: 38,
+      stock: 20,
+      active: true,
+    },
   ]);
 
   const count = await Product.countDocuments({});

--- a/app/api/orders/[id]/payment/route.js
+++ b/app/api/orders/[id]/payment/route.js
@@ -39,8 +39,10 @@ function buildPreview(order) {
         const plain = typeof item.toObject === "function" ? item.toObject() : item;
         const price = Number(plain.price || 0);
         const qty = Number(plain.qty || 0);
+        const rest = { ...plain };
+        delete rest.costPrice;
         return {
-          ...plain,
+          ...rest,
           _id: plain._id ? plain._id.toString() : plain._id,
           productId: plain.productId ? plain.productId.toString() : plain.productId,
           lineTotal: price * qty,

--- a/lib/serializeOrder.js
+++ b/lib/serializeOrder.js
@@ -26,7 +26,7 @@ function normalizePaymentStatus(value, total) {
   return Number(total || 0) > 0 ? "unpaid" : "paid";
 }
 
-export function serializeOrder(order, { includeSlip = false } = {}) {
+export function serializeOrder(order, { includeSlip = false, includeCost = false } = {}) {
   if (!order) return null;
   const plain = typeof order.toObject === "function" ? order.toObject() : order;
 
@@ -45,11 +45,19 @@ export function serializeOrder(order, { includeSlip = false } = {}) {
   };
 
   const items = Array.isArray(plain.items)
-    ? plain.items.map((item) => ({
-        ...item,
-        _id: normalizeId(item?._id),
-        productId: normalizeId(item?.productId),
-      }))
+    ? plain.items.map((item) => {
+        const plainItem =
+          typeof item?.toObject === "function" ? item.toObject() : item;
+        const normalizedItem = {
+          ...plainItem,
+          _id: normalizeId(plainItem?._id),
+          productId: normalizeId(plainItem?.productId),
+        };
+        if (!includeCost && "costPrice" in normalizedItem) {
+          delete normalizedItem.costPrice;
+        }
+        return normalizedItem;
+      })
     : [];
 
   const promotions = Array.isArray(plain.promotions)

--- a/models/Order.js
+++ b/models/Order.js
@@ -15,6 +15,7 @@ const OrderSchema = new Schema(
         title: String,
         price: Number,
         qty: Number,
+        costPrice: { type: Number, default: 0 },
       },
     ],
 

--- a/models/Product.js
+++ b/models/Product.js
@@ -7,6 +7,7 @@ const ProductSchema = new Schema(
     description: String,
     images: [String],
     price: Number,
+    costPrice: { type: Number, default: 0 },
     stock: Number,
     active: { type: Boolean, default: true },
     tags: [String],


### PR DESCRIPTION
## Summary
- add a costPrice field to products and persist item costs on new orders and exports
- extend admin stats to compute revenue/cost/profit for daily, weekly, and monthly periods and expose the new data in the dashboard
- refresh the admin UI to show profit metrics, format currency values, and allow editing product costs

## Testing
- no automated tests were run (lint script not defined)


------
https://chatgpt.com/codex/tasks/task_e_68db47e74454832da491adffee000746