### PR TITLE
Add cart toast notification and badge

### DIFF
--- a/app/(site)/layout.jsx
+++ b/app/(site)/layout.jsx
@@ -1,17 +1,19 @@
 import AuthProvider from "@/components/AuthProvider";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
-import { CartProvider } from "@/components/cart/CartProvider";
 import PromotionsTicker from "@/components/PromotionsTicker";
+import { CartProvider } from "@/components/cart/CartProvider";
+import CartToast from "@/components/cart/CartToast";
 
 export default function SiteLayout({ children }) {
   return (
     <AuthProvider>
-      <NavBar />
-      <PromotionsTicker />
       <CartProvider>
+        <NavBar />
+        <PromotionsTicker />
         <main className="min-h-[70vh]">{children}</main>
         <Footer />
+        <CartToast />
       </CartProvider>
     </AuthProvider>
   );

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { useCart } from "@/components/cart/CartProvider";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
@@ -7,38 +8,108 @@ export default function AddToCartButton({ product }) {
   const cart = useCart();
   const { status } = useSession();
   const router = useRouter();
+  const [quantity, setQuantity] = useState(1);
 
   const saleMode = product?.saleMode || "regular";
 
-  function handleClick() {
+  function redirectToPreorder() {
+    const target = product?._id ? `/preorder?product=${product._id}` : "/preorder";
+    router.push(target);
+  }
+
+  function ensureAuthenticated() {
+    const path =
+      typeof window !== "undefined"
+        ? `${window.location.pathname}${window.location.search}`
+        : "/";
+    const redirect = encodeURIComponent(path || "/");
+    router.push(`/login?redirect=${redirect}`);
+  }
+
+  function handleAddToCart() {
     if (saleMode === "preorder") {
-      const target = product?._id ? `/preorder?product=${product._id}` : "/preorder";
-      router.push(target);
+      redirectToPreorder();
       return;
     }
 
     if (status !== "authenticated") {
-      const path =
-        typeof window !== "undefined"
-          ? `${window.location.pathname}${window.location.search}`
-          : "/";
-      const redirect = encodeURIComponent(path || "/");
-      router.push(`/login?redirect=${redirect}`);
+      ensureAuthenticated();
       return;
     }
 
     cart.add(
       { productId: product._id, title: product.title, price: product.price },
-      1,
+      quantity,
+    );
+  }
+
+  function adjustQuantity(delta) {
+    setQuantity((prev) => {
+      const next = Number(prev) + delta;
+      if (!Number.isFinite(next) || next < 1) return 1;
+      if (next > 99) return 99;
+      return Math.floor(next);
+    });
+  }
+
+  function handleQuantityChange(event) {
+    const rawValue = Number(event.target.value);
+    if (!Number.isFinite(rawValue) || rawValue <= 0) {
+      setQuantity(1);
+      return;
+    }
+    if (rawValue > 99) {
+      setQuantity(99);
+      return;
+    }
+    setQuantity(Math.floor(rawValue));
+  }
+
+  if (saleMode === "preorder") {
+    return (
+      <button
+        className="px-4 py-2 rounded-full bg-[#ffe37f] text-[#3c1a09] text-sm font-semibold shadow-lg shadow-[rgba(91,61,252,0.2)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_30px_-16px_rgba(60,26,9,0.4)]"
+        onClick={handleAddToCart}
+      >
+        สั่ง Pre-order
+      </button>
     );
   }
 
   return (
-    <button
-      className="px-4 py-2 rounded-full bg-[#ffe37f] text-[#3c1a09] text-sm font-semibold shadow-lg shadow-[rgba(91,61,252,0.2)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_30px_-16px_rgba(60,26,9,0.4)]"
-      onClick={handleClick}
-    >
-      {saleMode === "preorder" ? "สั่ง Pre-order" : "เพิ่มลงตะกร้า"}
-    </button>
+    <div className="flex items-center gap-2">
+      <div className="flex items-center rounded-full border border-[#f5c486] bg-white text-[#3c1a09] shadow-sm">
+        <button
+          type="button"
+          aria-label="ลดจำนวน"
+          onClick={() => adjustQuantity(-1)}
+          className="h-9 w-9 text-lg leading-none text-[#3c1a09]/80 transition-colors hover:text-[#3c1a09]"
+        >
+          −
+        </button>
+        <input
+          type="number"
+          min="1"
+          max="99"
+          value={quantity}
+          onChange={handleQuantityChange}
+          className="h-9 w-12 border-x border-[#f5c486] bg-transparent text-center text-sm font-semibold focus:outline-none"
+        />
+        <button
+          type="button"
+          aria-label="เพิ่มจำนวน"
+          onClick={() => adjustQuantity(1)}
+          className="h-9 w-9 text-lg leading-none text-[#3c1a09]/80 transition-colors hover:text-[#3c1a09]"
+        >
+          +
+        </button>
+      </div>
+      <button
+        className="px-4 py-2 rounded-full bg-[#ffe37f] text-[#3c1a09] text-sm font-semibold shadow-lg shadow-[rgba(91,61,252,0.2)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_30px_-16px_rgba(60,26,9,0.4)]"
+        onClick={handleAddToCart}
+      >
+        เพิ่มลงตะกร้า
+      </button>
+    </div>
   );
 }

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -93,7 +93,7 @@ export default function AddToCartButton({ product }) {
           max="99"
           value={quantity}
           onChange={handleQuantityChange}
-          className="h-9 w-12 border-x border-[#f5c486] bg-transparent text-center text-sm font-semibold focus:outline-none"
+          className="h-9 w-12 border-x border-[#f5c486] bg-transparent text-center text-sm font-semibold focus:outline-none appearance-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
         <button
           type="button"

--- a/components/AddToCartButton.jsx
+++ b/components/AddToCartButton.jsx
@@ -41,6 +41,7 @@ export default function AddToCartButton({ product }) {
       { productId: product._id, title: product.title, price: product.price },
       quantity,
     );
+    setQuantity(1);
   }
 
   function adjustQuantity(delta) {

--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
 import { useState, useEffect, useRef } from "react";
+import { useCart } from "@/components/cart/CartProvider";
 
 
 const navItems = [
@@ -25,6 +26,8 @@ export default function NavBar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userMenuRef = useRef(null);
+  const cart = useCart();
+  const cartCount = cart?.count ?? 0;
 
   useEffect(() => {
     setMenuOpen(false);
@@ -72,15 +75,18 @@ export default function NavBar() {
         ? `/login?callbackUrl=${encodeURIComponent(item.href)}`
         : item.href;
     const active = path === item.href && (!item.requiresAuth || status === "authenticated");
+    const isCartLink = item.href === "/cart";
+    const showBadge = isCartLink && cartCount > 0;
+    const badgeCount = cartCount > 99 ? "99+" : cartCount;
     return (
       <Link
         key={item.href}
         href={targetHref}
-        className={`flex w-full items-center justify-between gap-3 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f7931e]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:w-auto md:justify-center ${
+        className={`relative flex w-full items-center justify-between gap-3 rounded-full border border-transparent px-4 py-2 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f7931e]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent md:w-auto md:justify-center ${
           active
             ? "bg-[#f7931e] text-white shadow-lg shadow-[rgba(247,147,30,0.35)]"
             : "text-[#3c1a09]/80 hover:text-[#f7931e]"
-        }`}
+        } ${showBadge ? "pr-6" : ""}`}
         onClick={() => setMenuOpen(false)}
       >
         {item.icon ? (
@@ -99,6 +105,11 @@ export default function NavBar() {
         ) : (
           item.label
         )}
+        {showBadge ? (
+          <span className="pointer-events-none absolute -top-1.5 -right-1.5 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-[#f7931e] px-1.5 text-[0.65rem] font-bold text-white shadow-lg shadow-[rgba(247,147,30,0.45)]">
+            {badgeCount}
+          </span>
+        ) : null}
       </Link>
     );
   };

--- a/components/cart/CartToast.jsx
+++ b/components/cart/CartToast.jsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useCart } from "./CartProvider";
+
+export default function CartToast() {
+  const cart = useCart();
+  const lastAddedItem = cart?.lastAddedItem;
+  const clearLastAdded = cart?.clearLastAdded ?? (() => {});
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (!lastAddedItem) return;
+
+    setIsVisible(true);
+
+    const hideTimer = setTimeout(() => {
+      setIsVisible(false);
+    }, 2400);
+
+    const clearTimer = setTimeout(() => {
+      clearLastAdded();
+    }, 2800);
+
+    return () => {
+      clearTimeout(hideTimer);
+      clearTimeout(clearTimer);
+    };
+  }, [lastAddedItem, clearLastAdded]);
+
+  const qtySummary = useMemo(() => {
+    if (!lastAddedItem) return "";
+    const totalQty = Number(lastAddedItem.totalQty || 0);
+    const addedQty = Number(lastAddedItem.qtyAdded || 0);
+
+    if (totalQty > 0 && addedQty > 0 && totalQty !== addedQty) {
+      return `ในตะกร้าทั้งหมด ${totalQty} ชิ้น`;
+    }
+
+    if (totalQty > 0) {
+      return `ในตะกร้า ${totalQty} ชิ้น`;
+    }
+
+    return "";
+  }, [lastAddedItem]);
+
+  if (!lastAddedItem) return null;
+
+  const productLabel = lastAddedItem.title ? `“${lastAddedItem.title}”` : "สินค้า";
+  const addedQty = Number(lastAddedItem.qtyAdded || 0) || 1;
+
+  return (
+    <div
+      className={`pointer-events-none fixed bottom-6 right-6 z-50 transition-all duration-300 sm:right-8 sm:bottom-8 ${
+        isVisible ? "translate-y-0 opacity-100" : "translate-y-3 opacity-0"
+      }`}
+    >
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-auto max-w-xs rounded-2xl border border-[#f5c486] bg-white/95 px-5 py-4 text-sm text-[#3c1a09] shadow-xl shadow-[rgba(60,26,9,0.2)]"
+      >
+        <p className="font-semibold">เพิ่มสินค้าในตะกร้าแล้ว</p>
+        <p className="mt-1 text-sm font-medium">
+          {productLabel} × {addedQty}
+        </p>
+        {qtySummary ? (
+          <p className="mt-1 text-xs text-[#3c1a09]/70">{qtySummary}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the site layout with the cart provider so navigation can access cart state
- show a badge with the number of cart items in the navigation cart link
- surface a toast notification whenever an item is added to the cart and persist the last-added item in the provider

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdf739b84832d8ef7a08b1975dda1