### PR TITLE
Constrain admin layout width

### DIFF
--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 import { AdminPopupProvider } from "@/components/admin/AdminPopupProvider";
+import { adminContentWidth } from "@/app/admin/theme";
 
 export const metadata = { title: "Admin | Sweet Cravings" };
 
@@ -12,33 +13,39 @@ export default function AdminLayout({ children }) {
 
         <main className="flex-1 lg:ml-0">
           <div className="sticky top-0 z-30 border-b border-[#F2D5AF] bg-[#FFF6EB]/90 backdrop-blur">
-            <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between lg:px-10">
-              <div>
-                <p className="text-sm font-semibold uppercase tracking-[0.32em] text-[#C08B4D]">
-                  Sweet Cravings Admin
-                </p>
-                <h1 className="mt-1 text-2xl font-bold text-[#3F2A1A]">
-                  แผงควบคุมการจัดการร้าน
-                </h1>
-              </div>
-              <div className="flex flex-wrap items-center gap-3">
-                <Link
-                  href="/"
-                  className="inline-flex items-center gap-2 rounded-full border border-[#E6C79C] bg-white/80 px-4 py-2 text-sm font-semibold text-[#8A5A33] shadow-[0_12px_28px_-20px_rgba(63,42,26,0.45)] transition hover:bg-[#FFF2DD]"
-                >
-                  🏬 กลับหน้าร้าน
-                </Link>
-                <Link
-                  href="/orders"
-                  className="inline-flex items-center gap-2 rounded-full bg-[#8A5A33] px-4 py-2 text-sm font-semibold text-white shadow-[0_16px_30px_-20px_rgba(63,42,26,0.55)] transition hover:bg-[#714528]"
-                >
-                  🛒 ดูร้านแบบลูกค้า
-                </Link>
+            <div className="px-5 py-4 lg:px-10">
+              <div
+                className={`${adminContentWidth} flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between`}
+              >
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.32em] text-[#C08B4D]">
+                    Sweet Cravings Admin
+                  </p>
+                  <h1 className="mt-1 text-2xl font-bold text-[#3F2A1A]">
+                    แผงควบคุมการจัดการร้าน
+                  </h1>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Link
+                    href="/"
+                    className="inline-flex items-center gap-2 rounded-full border border-[#E6C79C] bg-white/80 px-4 py-2 text-sm font-semibold text-[#8A5A33] shadow-[0_12px_28px_-20px_rgba(63,42,26,0.45)] transition hover:bg-[#FFF2DD]"
+                  >
+                    🏬 กลับหน้าร้าน
+                  </Link>
+                  <Link
+                    href="/orders"
+                    className="inline-flex items-center gap-2 rounded-full bg-[#8A5A33] px-4 py-2 text-sm font-semibold text-white shadow-[0_16px_30px_-20px_rgba(63,42,26,0.55)] transition hover:bg-[#714528]"
+                  >
+                    🛒 ดูร้านแบบลูกค้า
+                  </Link>
+                </div>
               </div>
             </div>
           </div>
 
-          <div className="px-5 pb-20 pt-8 lg:px-10">{children}</div>
+          <div className="px-5 pb-20 pt-8 lg:px-10">
+            <div className={`${adminContentWidth} space-y-8`}>{children}</div>
+          </div>
         </main>
       </div>
     </AdminPopupProvider>

--- a/app/admin/theme.js
+++ b/app/admin/theme.js
@@ -16,6 +16,8 @@ export const adminInsetCardShell =
 
 export const adminTableShell = `${adminSubSurfaceShell} overflow-hidden`;
 
+export const adminContentWidth = "mx-auto w-full max-w-6xl";
+
 export const adminFilterPill =
   "inline-flex items-center gap-2 rounded-full border border-[#E6C79C] bg-white/80 px-4 py-2 text-xs font-semibold text-[#8A5A33] shadow-[inset_0_1px_4px_rgba(63,42,26,0.08)]";
 


### PR DESCRIPTION
## Summary
- add a reusable `adminContentWidth` utility for constraining admin pages
- wrap admin header and main content with the shared width class for consistent sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3666f1380832d9a6b3864d54fe1dc