### PR TITLE
Highlight new product arrivals

### DIFF
--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -1,6 +1,7 @@
 import { connectToDatabase } from "@/lib/db";
 import { Product } from "@/models/Product";
 import { Review } from "@/models/Review";
+import { isNewArrival } from "@/lib/productUtils";
 import AddToCartButton from "@/components/AddToCartButton";
 import ReviewsShowcase from "@/components/ReviewsShowcase";
 
@@ -133,14 +134,22 @@ export default async function HomePage() {
           .lean(),
       ]);
 
-      products = (docs || []).map((d) => ({
-        _id: String(d._id),
-        title: d.title || "",
-        description: d.description || "",
-        price: d.price ?? 0,
-        images: Array.isArray(d.images) ? d.images : [],
-        saleMode: d.saleMode || null,
-      }));
+      const now = new Date();
+
+      products = (docs || []).map((d) => {
+        const createdAt = d.createdAt ? new Date(d.createdAt) : null;
+
+        return {
+          _id: String(d._id),
+          title: d.title || "",
+          description: d.description || "",
+          price: d.price ?? 0,
+          images: Array.isArray(d.images) ? d.images : [],
+          saleMode: d.saleMode || null,
+          createdAt: createdAt ? createdAt.toISOString() : null,
+          isNewArrival: isNewArrival({ createdAt }, { now }),
+        };
+      });
 
       featuredReviews = (reviews || []).map((r) => ({
         id: String(r._id),
@@ -517,6 +526,11 @@ export default async function HomePage() {
                         <span className="text-6xl opacity-30">🥟</span>
                       )}
                     </div>
+                    {p.isNewArrival && (
+                      <div className="absolute left-3 top-3 rounded-full bg-[var(--color-rose)] px-3 py-1 text-[10px] font-black uppercase tracking-wider text-white shadow-sm">
+                        ใหม่!
+                      </div>
+                    )}
                     {p.saleMode === "preorder" && (
                       <div className="absolute right-3 top-3 rounded-full bg-amber-400 px-3 py-1 text-[10px] font-black uppercase tracking-wider text-amber-900">
                         Pre-order

--- a/lib/productUtils.js
+++ b/lib/productUtils.js
@@ -1,0 +1,50 @@
+const DEFAULT_NEW_ARRIVAL_WINDOW_DAYS = 14;
+
+export function isNewArrival(product, options = {}) {
+  if (!product || typeof product !== "object") {
+    return false;
+  }
+
+  const {
+    days = DEFAULT_NEW_ARRIVAL_WINDOW_DAYS,
+    now = new Date(),
+    field = "createdAt",
+  } = options;
+
+  const windowDays = Math.max(0, Number(days));
+  if (!Number.isFinite(windowDays) || windowDays <= 0) {
+    return false;
+  }
+
+  const referenceDate = normalizeDate(now);
+  const createdAtValue = field in product ? product[field] : product.createdAt;
+  const createdAtDate = normalizeDate(createdAtValue);
+
+  if (!referenceDate || !createdAtDate) {
+    return false;
+  }
+
+  const threshold = new Date(referenceDate.getTime());
+  threshold.setDate(threshold.getDate() - windowDays);
+
+  return createdAtDate >= threshold;
+}
+
+function normalizeDate(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a reusable utility for detecting recently created products
- surface a "new" badge on the homepage menu when products fall within the arrival window

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e38d277788832d9d13444248e51047